### PR TITLE
Adjust CSV to pass operator-sdk scorecard

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -37,41 +37,41 @@ spec:
             size:
               description: Size sets the number of replicas to create. Defaults to 1.
               type: integer
-            AMQPUrl:
+            amqp_url:
               description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
                 'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
               type: string
-            useBasicAuth:
+            use_basic_auth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
               type: boolean
-            elasticUrl:
+            elastic_url:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
               type: string
-            elasticUser:
+            elastic_user:
               description: Basic Authentication username for ElasticSearch.
               type: string
-            elasticPass:
+            elastic_pass:
               description: Basic Authentication password for ElasticSearch.
               type: string
-            tlsSecretName:
+            tls_secret_name:
               description: Name of the Secret object that holds the TLS certificates and key for Elasticsearch.
                 Defaults to 'elasticsearch-es-cert'.
-            resetIndex:
+            reset_index:
               description: Reset the ElasticSearch index on load. Defaults to 'false'.
-            serviceType:
+            service_type:
               description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
               type: string
-            exporterHost:
+            exporter_host:
               description: Metrics URL for Prometheus to export. Defaults to "0.0.0.0".
               type: string
-            exporterPort:
+            exporter_port:
               description: Metrics port for Prometheus to export. Defaults to 8081.
               type: integer
-            cpuStats:
+            cpu_stats:
               description: Include CPU usage info in http requests (degrades performance). Defaults to 'false'.
               type: string
-            dataCount:
+            data_count:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
               type: string
             debug:
@@ -83,8 +83,29 @@ spec:
                 To avoid the round trip for every message, the use of prefetch can be used to allow the receiver to request messages be sent
                 in anticipation of them being sent to us.
               type: integer
-            containerImagePath:
+            container_image_path:
               description: Path to the container image this Operator will deploy. Value is defined as the standard registry/image_name:tag
                 format. Defaults to 'quay.io/infrawatch/smart-gateway:latest'
               type: string
-
+            use_timestamp:
+              description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
+                scraped for that metric.
+              type: boolean
+        status:
+          description: Status results of an instance of Smart Gateway
+          properties:
+            conditions:
+              description: The resulting conditions when a Smart Gateway is instantiated
+              items:
+                properties:
+                  status:
+                    type: string
+                  type:
+                    type: string
+                  reason:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                type: object
+              type: array
+          type: object

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
@@ -66,6 +66,55 @@ spec:
       - kind: SmartGateways
         name: ""
         version: v2alpha1
+      specDescriptors:
+      - description: Number of Smart Gateways to deploy
+        displayName: Size
+        path: size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Location of the AMQP endpoint to connect the Smart Gateway to
+        displayName: AMQP URL
+        path: amqp_url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Container image path
+        displayName: Container image path
+        path: container_image_path
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Number of messages that we can prefetch from AMQP 1.x. By enabling
+          prefetching, the smart gateway won't need to request every message individually
+          from the AMQP bus, resulting in a round trip for every request between sender
+          and receiver. To avoid the round trip for every message, the use of prefetch
+          can be used to allow the receiver to request messages be sent in anticipation
+          of them being sent to us.
+        displayName: Prefetch
+        path: prefetch
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Use the source timestamp (time when data was collected) rather
+          than let Prometheus write when the data was scraped for that metric.
+        displayName: Use Timestamp
+        path: use_timestamp
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Smart Gateway Service Type
+        displayName: Service Type
+        path: service_type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:metrics
+        - urn:alm:descriptor:com.tectonic.ui:select:events
+      - description: Enable additional debugging information to console output
+        displayName: Enable debugging
+        path: debug
+        x-descriptors:
+        - urn:alm:descriptor:tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Conditions provided by deployment
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       version: v2alpha1
   description: |-
     # Smart Gateway for Service Telemetry Framework

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -37,41 +37,41 @@ spec:
             size:
               description: Size sets the number of replicas to create. Defaults to 1.
               type: integer
-            AMQPUrl:
+            amqp_url:
               description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
                 'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
               type: string
-            useBasicAuth:
+            use_basic_auth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
               type: boolean
-            elasticUrl:
+            elastic_url:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
               type: string
-            elasticUser:
+            elastic_user:
               description: Basic Authentication username for ElasticSearch.
               type: string
-            elasticPass:
+            elastic_pass:
               description: Basic Authentication password for ElasticSearch.
               type: string
-            tlsSecretName:
+            tls_secret_name:
               description: Name of the Secret object that holds the TLS certificates and key for Elasticsearch.
                 Defaults to 'elasticsearch-es-cert'.
-            resetIndex:
+            reset_index:
               description: Reset the ElasticSearch index on load. Defaults to 'false'.
-            serviceType:
+            service_type:
               description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
               type: string
-            exporterHost:
+            exporter_host:
               description: Metrics URL for Prometheus to export. Defaults to "0.0.0.0".
               type: string
-            exporterPort:
+            exporter_port:
               description: Metrics port for Prometheus to export. Defaults to 8081.
               type: integer
-            cpuStats:
+            cpu_stats:
               description: Include CPU usage info in http requests (degrades performance). Defaults to 'false'.
               type: string
-            dataCount:
+            data_count:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
               type: string
             debug:
@@ -83,8 +83,29 @@ spec:
                 To avoid the round trip for every message, the use of prefetch can be used to allow the receiver to request messages be sent
                 in anticipation of them being sent to us.
               type: integer
-            containerImagePath:
+            container_image_path:
               description: Path to the container image this Operator will deploy. Value is defined as the standard registry/image_name:tag
                 format. Defaults to 'quay.io/infrawatch/smart-gateway:latest'
               type: string
-
+            use_timestamp:
+              description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
+                scraped for that metric.
+              type: boolean
+        status:
+          description: Status results of an instance of Smart Gateway
+          properties:
+            conditions:
+              description: The resulting conditions when a Smart Gateway is instantiated
+              items:
+                properties:
+                  status:
+                    type: string
+                  type:
+                    type: string
+                  reason:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                type: object
+              type: array
+          type: object


### PR DESCRIPTION
Make changes to the CRD and CSV files so that the Smart Gateway Operator will now
pass the operator-sdk scorecard fully.

Because of the way Ansible Operators work (where camelCase parameters are internally
converted to snake_case) it was required that the CRD spec descriptors were
also set to use snake_case all the way through.

Add additional spec and status descriptors, and flesh out any obviously missing
spec descriptors.

Closes #15