### PR TITLE
Create bundle metadata

### DIFF
--- a/build/update_csv.sh
+++ b/build/update_csv.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-operator-sdk olm-catalog gen-csv --csv-version 0.2.0 --operator-name smart-gateway-operator --update-crds
+operator-sdk generate csv --csv-version 0.2.0 --operator-name smart-gateway-operator --update-crds

--- a/deploy/olm-catalog/smart-gateway-operator/Dockerfile
+++ b/deploy/olm-catalog/smart-gateway-operator/Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=plain
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=smart-gateway-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+COPY /*.yaml /manifests/
+COPY /metadata/annotations.yaml /metadata/annotations.yaml

--- a/deploy/olm-catalog/smart-gateway-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: plain
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: smart-gateway-operator


### PR DESCRIPTION
Create the bundle metadata which is a newly available command in operator-sdk 0.15.2.

I created the bundle via this method:

bundle create --generate-only --directory ./deploy/olm-catalog/smart-gateway-operator --package smart-gateway-operator --channels alpha --default-channel alpha

Running the operator-sdk scorecard also passes fully when using the following command:

operator-sdk scorecard --bundle ./deploy/olm-catalog/smart-gateway-operator/metadata/