### PR TITLE
use_timestamp is a string from smart gateway viewpoint

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -90,7 +90,7 @@ spec:
             use_timestamp:
               description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
                 scraped for that metric.
-              type: boolean
+              type: string
         status:
           description: Status results of an instance of Smart Gateway
           properties:


### PR DESCRIPTION
Setting the CRD validation to boolean instead of string causes a mismatch between the expected
values that the CRD validation is expecting, and what the Smart Gateway is expecting. The smart
gateway expects the values to be passed to it as a string (looks for literal true/false vs
a boolean true/false).

This change makes the CRD validation reflect what the Smart Gateway expects to be passed.

Closes https://github.com/infrawatch/service-telemetry-operator/issues/65