### PR TITLE
Migrate back to camelCase for CRD and CR

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -43,7 +43,7 @@ spec:
               type: string
             useBasicAuth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
-              type: string
+              type: boolean
             elasticUrl:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
@@ -59,6 +59,7 @@ spec:
                 Defaults to 'elasticsearch-es-cert'.
             resetIndex:
               description: Reset the ElasticSearch index on load. Defaults to 'false'.
+              type: boolean
             serviceType:
               description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
               type: string
@@ -70,13 +71,13 @@ spec:
               type: integer
             cpuStats:
               description: Include CPU usage info in http requests (degrades performance). Defaults to 'false'.
-              type: string
+              type: boolean
             dataCount:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
-              type: string
+              type: integer
             debug:
               description: Enable verbose debugging statements. Defaults to 'false'.
-              type: string
+              type: boolean
             prefetch:
               description: Number of messages that we can prefetch from AMQP 1.x. By enabling prefetching, the smart gateway won't need to
                 request every message individually from the AMQP bus, resulting in a round trip for every request between sender and receiver.
@@ -90,7 +91,7 @@ spec:
             useTimestamp:
               description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
                 scraped for that metric.
-              type: string
+              type: boolean
         status:
           description: Status results of an instance of Smart Gateway
           properties:

--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -37,41 +37,41 @@ spec:
             size:
               description: Size sets the number of replicas to create. Defaults to 1.
               type: integer
-            amqp_url:
+            amqpUrl:
               description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
                 'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
               type: string
-            use_basic_auth:
+            useBasicAuth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
               type: string
-            elastic_url:
+            elasticUrl:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
               type: string
-            elastic_user:
+            elasticUser:
               description: Basic Authentication username for ElasticSearch.
               type: string
-            elastic_pass:
+            elasticPass:
               description: Basic Authentication password for ElasticSearch.
               type: string
-            tls_secret_name:
+            tlsSecretName:
               description: Name of the Secret object that holds the TLS certificates and key for Elasticsearch.
                 Defaults to 'elasticsearch-es-cert'.
-            reset_index:
+            resetIndex:
               description: Reset the ElasticSearch index on load. Defaults to 'false'.
-            service_type:
+            serviceType:
               description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
               type: string
-            exporter_host:
+            exporterHost:
               description: Metrics URL for Prometheus to export. Defaults to "0.0.0.0".
               type: string
-            exporter_port:
+            exporterPort:
               description: Metrics port for Prometheus to export. Defaults to 8081.
               type: integer
-            cpu_stats:
+            cpuStats:
               description: Include CPU usage info in http requests (degrades performance). Defaults to 'false'.
               type: string
-            data_count:
+            dataCount:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
               type: string
             debug:
@@ -83,11 +83,11 @@ spec:
                 To avoid the round trip for every message, the use of prefetch can be used to allow the receiver to request messages be sent
                 in anticipation of them being sent to us.
               type: integer
-            container_image_path:
+            containerImagePath:
               description: Path to the container image this Operator will deploy. Value is defined as the standard registry/image_name:tag
                 format. Defaults to 'quay.io/infrawatch/smart-gateway:latest'
               type: string
-            use_timestamp:
+            useTimestamp:
               description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
                 scraped for that metric.
               type: string

--- a/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.events_cr.yaml
+++ b/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.events_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloud1-events
 spec:
   size: 1
-  debug: "false"
+  debug: false
   serviceType: "events"
-  resetIndex: "false"
+  resetIndex: false
   prefetch: 0

--- a/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.events_cr.yaml
+++ b/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.events_cr.yaml
@@ -5,5 +5,6 @@ metadata:
 spec:
   size: 1
   debug: "false"
-  service_type: "events"
-# vim: set tabstop=2 shiftwidth=2 expandtab smartindent:
+  serviceType: "events"
+  resetIndex: "false"
+  prefetch: 0

--- a/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.metrics_cr.yaml
+++ b/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.metrics_cr.yaml
@@ -5,5 +5,6 @@ metadata:
 spec:
   size: 1
   debug: "false"
-  service_type: "metrics"
-# vim: set tabstop=2 shiftwidth=2 expandtab smartindent:
+  serviceType: "metrics"
+  useTimestamp: "true"
+  prefetch: 15000

--- a/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.metrics_cr.yaml
+++ b/deploy/crds/smartgateway.infra.watch_v2alpha1_smartgateway.metrics_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloud1-metrics
 spec:
   size: 1
-  debug: "false"
+  debug: false
   serviceType: "metrics"
-  useTimestamp: "true"
+  useTimestamp: true
   prefetch: 15000

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
@@ -11,9 +11,9 @@ metadata:
             "name": "cloud1-events"
           },
           "spec": {
-            "debug": "false",
+            "debug": false,
             "prefetch": 0,
-            "resetIndex": "false",
+            "resetIndex": false,
             "serviceType": "events",
             "size": 1
           }
@@ -25,11 +25,11 @@ metadata:
             "name": "cloud1-metrics"
           },
           "spec": {
-            "debug": "false",
+            "debug": false,
             "prefetch": 15000,
             "serviceType": "metrics",
             "size": 1,
-            "useTimestamp": "true"
+            "useTimestamp": true
           }
         }
       ]

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smart-gateway-operator.v0.2.0.clusterserviceversion.yaml
@@ -12,7 +12,9 @@ metadata:
           },
           "spec": {
             "debug": "false",
-            "service_type": "events",
+            "prefetch": 0,
+            "resetIndex": "false",
+            "serviceType": "events",
             "size": 1
           }
         },
@@ -24,8 +26,10 @@ metadata:
           },
           "spec": {
             "debug": "false",
-            "service_type": "metrics",
-            "size": 1
+            "prefetch": 15000,
+            "serviceType": "metrics",
+            "size": 1,
+            "useTimestamp": "true"
           }
         }
       ]
@@ -74,12 +78,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Location of the AMQP endpoint to connect the Smart Gateway to
         displayName: AMQP URL
-        path: amqp_url
+        path: amqpUrl
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Container image path
         displayName: Container image path
-        path: container_image_path
+        path: containerImagePath
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Number of messages that we can prefetch from AMQP 1.x. By enabling
@@ -95,12 +99,12 @@ spec:
       - description: Use the source timestamp (time when data was collected) rather
           than let Prometheus write when the data was scraped for that metric.
         displayName: Use Timestamp
-        path: use_timestamp
+        path: useTimestamp
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Smart Gateway Service Type
         displayName: Service Type
-        path: service_type
+        path: serviceType
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:metrics
         - urn:alm:descriptor:com.tectonic.ui:select:events

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -43,7 +43,7 @@ spec:
               type: string
             useBasicAuth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
-              type: string
+              type: boolean
             elasticUrl:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
@@ -59,6 +59,7 @@ spec:
                 Defaults to 'elasticsearch-es-cert'.
             resetIndex:
               description: Reset the ElasticSearch index on load. Defaults to 'false'.
+              type: boolean
             serviceType:
               description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
               type: string
@@ -70,13 +71,13 @@ spec:
               type: integer
             cpuStats:
               description: Include CPU usage info in http requests (degrades performance). Defaults to 'false'.
-              type: string
+              type: boolean
             dataCount:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
-              type: string
+              type: integer
             debug:
               description: Enable verbose debugging statements. Defaults to 'false'.
-              type: string
+              type: boolean
             prefetch:
               description: Number of messages that we can prefetch from AMQP 1.x. By enabling prefetching, the smart gateway won't need to
                 request every message individually from the AMQP bus, resulting in a round trip for every request between sender and receiver.
@@ -90,7 +91,7 @@ spec:
             useTimestamp:
               description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
                 scraped for that metric.
-              type: string
+              type: boolean
         status:
           description: Status results of an instance of Smart Gateway
           properties:

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -37,41 +37,41 @@ spec:
             size:
               description: Size sets the number of replicas to create. Defaults to 1.
               type: integer
-            amqp_url:
+            amqpUrl:
               description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
                 'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
               type: string
-            use_basic_auth:
+            useBasicAuth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
               type: string
-            elastic_url:
+            elasticUrl:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
               type: string
-            elastic_user:
+            elasticUser:
               description: Basic Authentication username for ElasticSearch.
               type: string
-            elastic_pass:
+            elasticPass:
               description: Basic Authentication password for ElasticSearch.
               type: string
-            tls_secret_name:
+            tlsSecretName:
               description: Name of the Secret object that holds the TLS certificates and key for Elasticsearch.
                 Defaults to 'elasticsearch-es-cert'.
-            reset_index:
+            resetIndex:
               description: Reset the ElasticSearch index on load. Defaults to 'false'.
-            service_type:
+            serviceType:
               description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
               type: string
-            exporter_host:
+            exporterHost:
               description: Metrics URL for Prometheus to export. Defaults to "0.0.0.0".
               type: string
-            exporter_port:
+            exporterPort:
               description: Metrics port for Prometheus to export. Defaults to 8081.
               type: integer
-            cpu_stats:
+            cpuStats:
               description: Include CPU usage info in http requests (degrades performance). Defaults to 'false'.
               type: string
-            data_count:
+            dataCount:
               description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
               type: string
             debug:
@@ -83,11 +83,11 @@ spec:
                 To avoid the round trip for every message, the use of prefetch can be used to allow the receiver to request messages be sent
                 in anticipation of them being sent to us.
               type: integer
-            container_image_path:
+            containerImagePath:
               description: Path to the container image this Operator will deploy. Value is defined as the standard registry/image_name:tag
                 format. Defaults to 'quay.io/infrawatch/smart-gateway:latest'
               type: string
-            use_timestamp:
+            useTimestamp:
               description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
                 scraped for that metric.
               type: string

--- a/roles/smartgateway/templates/events-configmap.yaml.j2
+++ b/roles/smartgateway/templates/events-configmap.yaml.j2
@@ -17,7 +17,7 @@ data:
             "ResetIndex": {{ reset_index | default('false') }},
             "ServiceType": "{{ service_type | default('events') }}",
             "Debug": {{ debug | default('false') }},
-            "Prefetch": {{ prefetch | default('0') }},
+            "Prefetch": {{ prefetch | default(0) }},
             "UniqueName": "{{ unique_name | default(meta.name + '-smartgateway') }}",
             "AlertManagerEnabled": {{ alert_manager_enabled | default('false') }},
             "AlertManagerURL": "{{ alert_manager_url | default('') }}",

--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -8,11 +8,11 @@ data:
     {
             "AMQP1MetricURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
             "Exporterhost": "{{ exporter_host | default('0.0.0.0') }}",
-            "Exporterport": {{ exporter_port | default('8081') }},
+            "Exporterport": {{ exporter_port | default(8081) }},
             "CPUStats": {{ cpu_stats | default('false') }},
-            "DataCount": {{ data_count | default('-1') }},
+            "DataCount": {{ data_count | default(-1) }},
             "ServiceType": "{{ service_type | default('metrics') }}",
             "Debug": {{ debug | default('true') }},
-            "Prefetch": {{ prefetch | default('1000') }},
+            "Prefetch": {{ prefetch | default(1000) }},
             "UseTimestamp": {{ use_timestamp | default('true') }}
     }


### PR DESCRIPTION
To keep things consistent across all our CRD interactions, change the CRD to make
use of camelCase instead of snake_case directly. The Ansible Operator will automatically
convert the camelCase into snake_case automatically at run time, so the existing
variable names in the templates is still valid and necessary.