### PR TITLE
Fix broken type validation in CRD

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -43,7 +43,7 @@ spec:
               type: string
             use_basic_auth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
-              type: boolean
+              type: string
             elastic_url:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -43,7 +43,7 @@ spec:
               type: string
             use_basic_auth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
-              type: boolean
+              type: string
             elastic_url:
               description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
                 Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
@@ -90,7 +90,7 @@ spec:
             use_timestamp:
               description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
                 scraped for that metric.
-              type: boolean
+              type: string
         status:
           description: Status results of an instance of Smart Gateway
           properties:


### PR DESCRIPTION
Fix broken type validation in the CRD. The Smart Gateway expects some boolean
looking values to actually be passed as a string. Some recent changes in the CRD
to clean things up has resulted in setting the validation types to boolean when
the SG actually expects them to be passed as literal strings.

This change updates the CRD and executes the ./build/update_csv.sh script to
keep everything in sync.