### PR TITLE
Migrate to new AMQP1Connections configuration options

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -41,6 +41,9 @@ spec:
               description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
                 'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
               type: string
+            amqpDataSource:
+              description: The expected data source of the messages received from the address configured in amqpUrl. Available values include 'universal', 'collectd', and 'ceilometer'.
+              type: string
             useBasicAuth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
               type: boolean

--- a/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/0.2.0/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -41,6 +41,9 @@ spec:
               description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
                 'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
               type: string
+            amqpDataSource:
+              description: The expected data source of the messages received from the address configured in amqpUrl. Available values include 'universal', 'collectd', and 'ceilometer'.
+              type: string
             useBasicAuth:
               description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
               type: boolean

--- a/roles/smartgateway/templates/events-configmap.yaml.j2
+++ b/roles/smartgateway/templates/events-configmap.yaml.j2
@@ -7,7 +7,10 @@ metadata:
 data:
   "smartgateway_config.json": |
     {
-            "AMQP1EventURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/notify') }}",
+            "AMQP1Connections": {
+              "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/notify') }}",
+              "DataSource": "{{ amqp_data_source | default('collectd') }}"
+            },
             "ElasticHostURL": "{{ elastic_url | default('elasticsearch.' + meta.namespace + '.svc:9200') }}",
             "UseBasicAuth": {{ use_basic_auth | default('false') | lower }},
 {% if use_basic_auth %}

--- a/roles/smartgateway/templates/events-configmap.yaml.j2
+++ b/roles/smartgateway/templates/events-configmap.yaml.j2
@@ -7,30 +7,32 @@ metadata:
 data:
   "smartgateway_config.json": |
     {
-            "AMQP1Connections": {
-              "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/notify') }}",
-              "DataSource": "{{ amqp_data_source | default('collectd') }}"
-            },
-            "ElasticHostURL": "{{ elastic_url | default('elasticsearch.' + meta.namespace + '.svc:9200') }}",
-            "UseBasicAuth": {{ use_basic_auth | default('false') | lower }},
+      "AMQP1Connections": [
+        {
+          "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/notify') }}",
+          "DataSource": "{{ amqp_data_source | default('collectd') }}"
+        }
+      ],
+      "ElasticHostURL": "{{ elastic_url | default('elasticsearch.' + meta.namespace + '.svc:9200') }}",
+      "UseBasicAuth": {{ use_basic_auth | default('false') | lower }},
 {% if use_basic_auth %}
-            "ElasticUser": "{{ elastic_user | default('elastic') }}",
-            "ElasticPass": "{{ elastic_pass | default('elastic') }}",
+      "ElasticUser": "{{ elastic_user | default('elastic') }}",
+      "ElasticPass": "{{ elastic_pass | default('elastic') }}",
 {% endif %}
-            "ResetIndex": {{ reset_index | default('false') | lower }},
-            "ServiceType": "{{ service_type | default('events') }}",
-            "Debug": {{ debug | default('false') | lower }},
-            "Prefetch": {{ prefetch | default(0) }},
-            "UniqueName": "{{ unique_name | default(meta.name + '-smartgateway') }}",
-            "AlertManagerEnabled": {{ alert_manager_enabled | default('false') | lower }},
-            "AlertManagerURL": "{{ alert_manager_url | default('') }}",
-            "APIEnabled": {{ api_enabled | default('false') | lower }},
-            "APIEndpointURL": "{{ api_endpoint_url | default('') }}",
-            "PublishEventEnabled": {{ publish_event_enabled | default('false') | lower }},
-            "AMQP1PublishURL": "{{ amqp_publish_url | default('') }}",
-            "TlsClientCert": "{{ tls_client_cert | default('') }}",
-            "TlsClientKey": "{{ tls_client_key | default('') }}",
-            "TlsCaCert": "{{ tls_ca_cert | default('') }}",
-            "TlsServerName": "{{ tls_server_name | default('') }}",
-            "UseTls": {{ use_tls | default('false') | lower }}
+      "ResetIndex": {{ reset_index | default('false') | lower }},
+      "ServiceType": "{{ service_type | default('events') }}",
+      "Debug": {{ debug | default('false') | lower }},
+      "Prefetch": {{ prefetch | default(0) }},
+      "UniqueName": "{{ unique_name | default(meta.name + '-smartgateway') }}",
+      "AlertManagerEnabled": {{ alert_manager_enabled | default('false') | lower }},
+      "AlertManagerURL": "{{ alert_manager_url | default('') }}",
+      "APIEnabled": {{ api_enabled | default('false') | lower }},
+      "APIEndpointURL": "{{ api_endpoint_url | default('') }}",
+      "PublishEventEnabled": {{ publish_event_enabled | default('false') | lower }},
+      "AMQP1PublishURL": "{{ amqp_publish_url | default('') }}",
+      "TlsClientCert": "{{ tls_client_cert | default('') }}",
+      "TlsClientKey": "{{ tls_client_key | default('') }}",
+      "TlsCaCert": "{{ tls_ca_cert | default('') }}",
+      "TlsServerName": "{{ tls_server_name | default('') }}",
+      "UseTls": {{ use_tls | default('false') | lower }}
     }

--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -6,7 +6,10 @@ metadata:
 data:
   "smartgateway_config.json": |
     {
-            "AMQP1MetricURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
+            "AMQP1Connections": {
+              "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
+              "DataSource": "{{ amqp_data_source | default('collectd') }}"
+            },
             "Exporterhost": "{{ exporter_host | default('0.0.0.0') }}",
             "Exporterport": {{ exporter_port | default(8081) }},
             "CPUStats": {{ cpu_stats | default('false') | lower }},

--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -6,12 +6,7 @@ metadata:
 data:
   "smartgateway_config.json": |
     {
-      "AMQP1Connections": [
-        {
-          "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
-          "DataSource": "{{ amqp_data_source | default('collectd') }}"
-        }
-      ],
+      "AMQP1MetricURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
       "Exporterhost": "{{ exporter_host | default('0.0.0.0') }}",
       "Exporterport": {{ exporter_port | default(8081) }},
       "CPUStats": {{ cpu_stats | default('false') | lower }},

--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -6,16 +6,18 @@ metadata:
 data:
   "smartgateway_config.json": |
     {
-            "AMQP1Connections": {
-              "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
-              "DataSource": "{{ amqp_data_source | default('collectd') }}"
-            },
-            "Exporterhost": "{{ exporter_host | default('0.0.0.0') }}",
-            "Exporterport": {{ exporter_port | default(8081) }},
-            "CPUStats": {{ cpu_stats | default('false') | lower }},
-            "DataCount": {{ data_count | default(-1) }},
-            "ServiceType": "{{ service_type | default('metrics') }}",
-            "Debug": {{ debug | default('true') | lower }},
-            "Prefetch": {{ prefetch | default(1000) }},
-            "UseTimestamp": {{ use_timestamp | default('true') | lower }}
+      "AMQP1Connections": [
+        {
+          "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
+          "DataSource": "{{ amqp_data_source | default('collectd') }}"
+        }
+      ],
+      "Exporterhost": "{{ exporter_host | default('0.0.0.0') }}",
+      "Exporterport": {{ exporter_port | default(8081) }},
+      "CPUStats": {{ cpu_stats | default('false') | lower }},
+      "DataCount": {{ data_count | default(-1) }},
+      "ServiceType": "{{ service_type | default('metrics') }}",
+      "Debug": {{ debug | default('true') | lower }},
+      "Prefetch": {{ prefetch | default(1000) }},
+      "UseTimestamp": {{ use_timestamp | default('true') | lower }}
     }


### PR DESCRIPTION
Migrate to using the new AMQP1Connections configuration options which allows for the
setup of the URL and DataSource. The use of DataSource is for when we're running multiple
Smart Gateway instances for different data sources, which allows for the creation of
indexes and such that matches the expected data source.

Closes #42