### PR TITLE
Use new connection configuration for metrics

### DIFF
--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,7 +7,12 @@ metadata:
 data:
   "smartgateway_config.json": |
     {
-      "AMQP1MetricURL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
+      "AMQP1Connections": [
+        {
+          "URL": "{{ amqp_url | default('messaging-internal-' + meta.name + '.' + meta.namespace + '.svc:5672/collectd/telemetry') }}",
+          "DataSource": "{{ amqp_data_source | default('collectd') }}"
+        }
+      ],
       "Exporterhost": "{{ exporter_host | default('0.0.0.0') }}",
       "Exporterport": {{ exporter_port | default(8081) }},
       "CPUStats": {{ cpu_stats | default('false') | lower }},


### PR DESCRIPTION
AMQP1Connections parameter should be used instead of nonflexible AMQP1Url.

Depends-On: https://github.com/infrawatch/smart-gateway/pull/83