### PR TITLE
Fix amqpDataSource

### DIFF
--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -23,7 +23,7 @@ spec:
         smart-gateway: '{{ meta.name }}'
     spec:
       containers:
-{% if (service_type == 'metrics') and (amqpDataSource == 'collectd') %}
+{% if (service_type == 'metrics') and (amqp_data_source == 'collectd') %}
       - name: bridge
         image: '{{ bridge_container_image_path }}'
         args:
@@ -71,7 +71,7 @@ spec:
         - name: "{{ service_type }}"
           containerPort: 8081
       volumes:
-{%   if (service_type == 'metrics') and (amqpDataSource == 'collectd') %}
+{%   if (service_type == 'metrics') and (amqp_data_source == 'collectd') %}
       - name: socket-dir
         emptyDir: {}
 {%   endif %}

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -70,6 +70,7 @@ spec:
         ports:
         - name: "{{ service_type }}"
           containerPort: 8081
+{%   endif %}
       volumes:
 {%   if (service_type == 'metrics') and (amqp_data_source == 'collectd') %}
       - name: socket-dir
@@ -83,4 +84,3 @@ spec:
         secret:
           secretName: {{ tls_secret_name }}
 {%   endif %}
-{% endif %}


### PR DESCRIPTION
CC: @leifmadsen @paramite purely an FYI PR for a quick fix

Remember when I said I hadn't tested the amqpDataSource change?

First it did this:

```
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'amqpDataSource' is undefined\n\nThe error appears to be in '/opt/ansible/roles/smartgateway/tasks/main.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Setup Smart Gateway\n  ^ here\n"}
```

Turned out to the the ^*@#ing camelCase to snake_case auto-converter biting me again!

Then it did this:

```
failed: [localhost] (item={'name': 'deployment.yaml.j2'}) => {"ansible_loop_var": "item", "changed": false, "error": 422, "item": {"name": "deployment.yaml.j2"}, "msg": "Failed to create object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Deployment.apps \\\\\"stf-default-collectd-telemetry-smartgateway\\\\\" is invalid: [spec.template.spec.containers[0].volumeMounts[0].name: Not found: \\\\\"socket-dir\\\\\", spec.template.spec.containers[1].volumeMounts[0].name: Not found: \\\\\"socket-dir\\\\\"]\",\"reason\":\"Invalid\",\"details\":{\"name\":\"stf-default-collectd-telemetry-smartgateway\",\"group\":\"apps\",\"kind\":\"Deployment\",\"causes\":[{\"reason\":\"FieldValueNotFound\",\"message\":\"Not found: \\\\\"socket-dir\\\\\"\",\"field\":\"spec.template.spec.containers[0].volumeMounts[0].name\"},{\"reason\":\"FieldValueNotFound\",\"message\":\"Not found: \\\\\"socket-dir\\\\\"\",\"field\":\"spec.template.spec.containers[1].volumeMounts[0].name\"}]},\"code\":422}\\n'", "reason": "Unprocessable Entity", "status": 422}
```

One of the new conditionals broke the volume definitions in the deployment.

Now it does this:

```
stf-default-collectd-telemetry-smartgateway-78b7ccb674-22d29      2/2     Running   0          8s
```
and this:
```
*** [SUCCESS] Smoke test job completed successfully
```
