### PR TITLE
Bump Operator-SDK base image to v0.16.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.14.1
+FROM quay.io/operator-framework/ansible-operator:v0.16.0
 
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
This bumps the Operator SDK base image to a version that matches the downstream v4.5.0 base image.