### PR TITLE
Reload Smart Gateways when ConfigMap changes

### DIFF
--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -10,16 +10,38 @@
     metrics_container_image_path: "{{ lookup('env', 'CORE_SMARTGATEWAY_IMAGE') | default('quay.io/infrawatch/sg-core:latest', true) }}"
     bridge_container_image_path: "{{ lookup('env', 'BRIDGE_SMARTGATEWAY_IMAGE') | default('quay.io/infrawatch/sg-bridge:latest', true) }}"
 
-- name: Setup Smart Gateway
-  k8s:
-    state: "{{ state }}"
-    definition: "{{ lookup('template', item.name) | from_yaml }}"
+- name: Get Smart Gateway ConfigMap Environment
+  set_fact:
+    smartgateway_resource_configmap:
+      env: "{{ lookup('template', item.name) | from_yaml }}"
   when: item.to_load | default(True)
   loop:
     - name: events-configmap.yaml.j2
       to_load: "{{ True if 'events' in service_type else False }}"
     - name: ceilometer-metrics-configmap.yaml.j2
       to_load: "{{ True if 'metrics' in service_type and amqp_data_source == 'ceilometer' else False }}"
+
+- name: Debug ConfigMap
+  debug:
+    var: smartgateway_resource_configmap | from_yaml
+
+- name: Setup the ConfigMaps
+  k8s:
+    state: "{{ state }}"
+    append_hash: yes
+    definition: "{{ smartgateway_resource_configmap.env }}"
+  when: smartgateway_resource_configmap is defined
+
+- name: Debug Deployment
+  debug:
+    var: lookup('template', 'deployment.yaml.j2') | from_yaml
+
+- name: Deploy Smart Gateway
+  k8s:
+    state: "{{ state }}"
+    definition: "{{ lookup('template', item.name) | from_yaml }}"
+  when: item.to_load | default(True)
+  loop:
     - name: deployment.yaml.j2
     - name: service.yaml.j2
       to_load: "{{ True if 'metrics' in service_type else False }}"

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -10,6 +10,10 @@
     metrics_container_image_path: "{{ lookup('env', 'CORE_SMARTGATEWAY_IMAGE') | default('quay.io/infrawatch/sg-core:latest', true) }}"
     bridge_container_image_path: "{{ lookup('env', 'BRIDGE_SMARTGATEWAY_IMAGE') | default('quay.io/infrawatch/sg-bridge:latest', true) }}"
 
+# only one of these is expected to be true
+# -- events SG (collectd, ceilometer) both use legacy config, thus events-configmap.yaml
+# -- metrics SG (ceilometer) uses ceilometer-metrics-configmap
+# -- metrics SG (collectd) only has the Deployment manifest updated due to direct call of configurations (no ConfigMap)
 - name: Get Smart Gateway ConfigMap Environment
   set_fact:
     smartgateway_resource_configmap:
@@ -21,27 +25,16 @@
     - name: ceilometer-metrics-configmap.yaml.j2
       to_load: "{{ True if 'metrics' in service_type and amqp_data_source == 'ceilometer' else False }}"
 
-- name: Debug ConfigMap
-  debug:
-    var: smartgateway_resource_configmap | from_yaml
-
-- name: Setup the ConfigMaps
-  k8s:
-    state: "{{ state }}"
-    append_hash: yes
-    definition: "{{ smartgateway_resource_configmap.env }}"
-  when: smartgateway_resource_configmap is defined
-
-- name: Debug Deployment
-  debug:
-    var: lookup('template', 'deployment.yaml.j2') | from_yaml
-
 - name: Deploy Smart Gateway
   k8s:
     state: "{{ state }}"
     definition: "{{ lookup('template', item.name) | from_yaml }}"
   when: item.to_load | default(True)
   loop:
+    - name: events-configmap.yaml.j2
+      to_load: "{{ True if 'events' in service_type else False }}"
+    - name: ceilometer-metrics-configmap.yaml.j2
+      to_load: "{{ True if 'metrics' in service_type and amqp_data_source == 'ceilometer' else False }}"
     - name: deployment.yaml.j2
     - name: service.yaml.j2
       to_load: "{{ True if 'metrics' in service_type else False }}"

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -21,6 +21,9 @@ spec:
       labels:
         app: smart-gateway
         smart-gateway: '{{ meta.name }}'
+{% if smartgateway_resource_configmap is defined %}
+        sg-config-resource-name: {{ smartgateway_resource_configmap.env | k8s_config_resource_name }}
+{% endif %}
     spec:
       containers:
 {% if (service_type == 'metrics') and (amqp_data_source == 'collectd') %}
@@ -81,7 +84,7 @@ spec:
 {% if smartgateway_resource_configmap is defined %}
       - name: sg-config
         configMap:
-          name: {{ smartgateway_resource_configmap.env | k8s_config_resource_name }}
+          name: {{ meta.name }}-smartgateway
 {%   if service_type == 'events' %}
       - name: elastic-certs
         secret:

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -50,12 +50,14 @@ spec:
 {% else %}
       - name: smart-gateway
         image: '{{ events_container_image_path }}'
+{%   if smartgateway_resource_configmap is defined %}
         volumeMounts:
         - name: sg-config
           mountPath: /config
-{%   if service_type == 'events' %}
+{%     if service_type == 'events' %}
         - name: elastic-certs
           mountPath: /config/certs
+{%     endif %}
 {%   endif %}
         args:
           - '-config=/config/smartgateway_config.json'
@@ -70,17 +72,19 @@ spec:
         ports:
         - name: "{{ service_type }}"
           containerPort: 8081
-{%   endif %}
+{% endif %}
       volumes:
-{%   if (service_type == 'metrics') and (amqp_data_source == 'collectd') %}
+{% if (service_type == 'metrics') and (amqp_data_source == 'collectd') %}
       - name: socket-dir
         emptyDir: {}
-{%   endif %}
+{% endif %}
+{% if smartgateway_resource_configmap is defined %}
       - name: sg-config
         configMap:
-          name: "{{ meta.name }}-smartgateway"
+          name: {{ smartgateway_resource_configmap.env | k8s_config_resource_name }}
 {%   if service_type == 'events' %}
       - name: elastic-certs
         secret:
           secretName: {{ tls_secret_name }}
 {%   endif %}
+{% endif %}


### PR DESCRIPTION
Changes to support ability to reload Smart Gateways when the ConfigMap changes. Uses
the k8s_config_resource_name module along with the append_hash option of the k8s module
to provide a unique name for the ConfigMap so that it can be referenced by the Deployment.

When the contents of the ConfigMap change, the hash changes, resulting in a new ConfigMap
being created, and a new resource name being used in the Deployment. When the Deployment is
changed, the signals Kubernetes to update the Deployment, resulting in a new pod running
which results in the configuration file being parsed again.

Still needs some additional logic because this current iteration results in multiple
ConfigMaps being created and old ones not cleaned up.
