### PR TITLE
Fixed collectd timestamp propagation

### DIFF
--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -4,4 +4,5 @@ size: 1
 state: present
 prometheus_scrape_interval: 1s
 use_basic_auth: false
+use_timestamp: true
 tls_secret_name: elasticsearch-es-cert

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -41,6 +41,9 @@ spec:
       - name: smart-gateway
         image: '{{ metrics_container_image_path }}'
         args:
+{% if use_timestamp %}
+        - -usetimestamp
+{% endif %}
         - -promhost
         - 0.0.0.0
         - unix


### PR DESCRIPTION
I needed this for testing in my HA work, and I think timestamp propagation is basically required for any useful HA.

I've tested adding the argument to the deployment, but not actually this code. It's also used here: https://github.com/infrawatch/smart-gateway-operator/blob/6d8dfb76c2a15e1cc77ef9c1388d334133a805aa/roles/smartgateway/templates/ceilometer-metrics-configmap.yaml.j2#L23