### PR TITLE
Move to latest channel by default

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,8 +4,11 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=smart-gateway-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=stable
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.bundle.channels.v1=latest
+LABEL operators.operatorframework.io.bundle.channel.default.v1=latest
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
+LABEL operators.operatorframework.io.metrics.project_layout=ansible
 
 COPY deploy/olm-catalog/smart-gateway-operator/manifests /manifests/
-COPY deploy/olm-catalog/smart-gateway-operator/metadata/annotations.yaml /metadata/annotations.yaml
+COPY deploy/olm-catalog/smart-gateway-operator/metadata /metadata/

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -40,6 +40,8 @@ metadata:
     createdAt: "2019-11-14T14:49:00Z"
     description: Operator for managing the Smart Gateway Custom Resources, resulting
       in deployments of the Smart Gateway.
+    operators.operatorframework.io/builder: operator-sdk-v0.19.4
+    operators.operatorframework.io/project_layout: ansible
     repository: https://github.com/infrawatch/smart-gateway-operator
     support: Red Hat (CloudOps)
   name: smart-gateway-operator.v2.0.1

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -1,6 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: smartgateways.smartgateway.infra.watch
 spec:
   group: smartgateway.infra.watch
@@ -10,13 +11,8 @@ spec:
     plural: smartgateways
     singular: smartgateway
   scope: Namespaced
-  version: v2alpha1
   subresources:
     status: {}
-  versions:
-  - name: v2alpha1
-    served: true
-    storage: true
   validation:
     openAPIV3Schema:
       properties:
@@ -34,37 +30,39 @@ spec:
           description: 'SmartGatewaySpec is a specification of the desired behavior
             of the Smartgateway deployment. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           properties:
-            size:
-              description: Size sets the number of replicas to create. Defaults to 1.
-              type: integer
-            amqpUrl:
-              description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry. Defaults to using
-                'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
-              type: string
             amqpDataSource:
-              description: The expected data source of the messages received from the address configured in amqpUrl. Available values include 'universal', 'collectd', and 'ceilometer'.
+              description: The expected data source of the messages received from
+                the address configured in amqpUrl. Available values include 'universal',
+                'collectd', and 'ceilometer'.
               type: string
-            useBasicAuth:
-              description: Whether to use basic authentication or not when connecting to ElasticSearch. Default is 'false'
+            amqpUrl:
+              description: AMQP1.x listener example 127.0.0.1:5672/collectd/telemetry.
+                Defaults to using 'messaging-internal-<name>.<namespace>.src:5672/collectd/telemetry'.
+              type: string
+            containerImagePath:
+              description: Path to the container image this Operator will deploy.
+                Value is defined as the standard registry/image_name:tag format.
+              type: string
+            cpuStats:
+              description: Include CPU usage info in http requests (degrades performance).
+                Defaults to 'false'.
               type: boolean
-            elasticUrl:
-              description: URL for ElasticSearch endpoing to connect when the Smart Gateway is operating as an 'events' service type.
-                Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
-              type: string
-            elasticUser:
-              description: Basic Authentication username for ElasticSearch.
-              type: string
+            dataCount:
+              description: Stop after receiving this many messages in total (-1 forever).
+                Defaults to '-1'.
+              type: integer
+            debug:
+              description: Enable verbose debugging statements. Defaults to 'false'.
+              type: boolean
             elasticPass:
               description: Basic Authentication password for ElasticSearch.
               type: string
-            tlsSecretName:
-              description: Name of the Secret object that holds the TLS certificates and key for Elasticsearch.
-                Defaults to 'elasticsearch-es-cert'.
-            resetIndex:
-              description: Reset the ElasticSearch index on load. Defaults to 'false'.
-              type: boolean
-            serviceType:
-              description: The service type for this smart gateway. One of 'metrics' or 'events'. Defaults to 'metrics'.
+            elasticUrl:
+              description: URL for ElasticSearch endpoing to connect when the Smart
+                Gateway is operating as an 'events' service type. Defaults to 'elasticsearch-es-http.<namespace>.svc:9200'.
+              type: string
+            elasticUser:
+              description: Basic Authentication username for ElasticSearch.
               type: string
             exporterHost:
               description: Metrics URL for Prometheus to export. Defaults to "0.0.0.0".
@@ -72,28 +70,37 @@ spec:
             exporterPort:
               description: Metrics port for Prometheus to export. Defaults to 8081.
               type: integer
-            cpuStats:
-              description: Include CPU usage info in http requests (degrades performance). Defaults to 'false'.
-              type: boolean
-            dataCount:
-              description: Stop after receiving this many messages in total (-1 forever). Defaults to '-1'.
-              type: integer
-            debug:
-              description: Enable verbose debugging statements. Defaults to 'false'.
-              type: boolean
             prefetch:
-              description: Number of messages that we can prefetch from AMQP 1.x. By enabling prefetching, the smart gateway won't need to
-                request every message individually from the AMQP bus, resulting in a round trip for every request between sender and receiver.
-                To avoid the round trip for every message, the use of prefetch can be used to allow the receiver to request messages be sent
-                in anticipation of them being sent to us.
+              description: Number of messages that we can prefetch from AMQP 1.x.
+                By enabling prefetching, the smart gateway won't need to request every
+                message individually from the AMQP bus, resulting in a round trip
+                for every request between sender and receiver. To avoid the round
+                trip for every message, the use of prefetch can be used to allow the
+                receiver to request messages be sent in anticipation of them being
+                sent to us.
               type: integer
-            containerImagePath:
-              description: Path to the container image this Operator will deploy. Value is defined as the standard registry/image_name:tag
-                format.
+            resetIndex:
+              description: Reset the ElasticSearch index on load. Defaults to 'false'.
+              type: boolean
+            serviceType:
+              description: The service type for this smart gateway. One of 'metrics'
+                or 'events'. Defaults to 'metrics'.
               type: string
+            size:
+              description: Size sets the number of replicas to create. Defaults to
+                1.
+              type: integer
+            tlsSecretName:
+              description: Name of the Secret object that holds the TLS certificates
+                and key for Elasticsearch. Defaults to 'elasticsearch-es-cert'.
+            useBasicAuth:
+              description: Whether to use basic authentication or not when connecting
+                to ElasticSearch. Default is 'false'
+              type: boolean
             useTimestamp:
-              description: Use the source timestamp (time when data was collected) rather than let Prometheus write when the data was 
-                scraped for that metric.
+              description: Use the source timestamp (time when data was collected)
+                rather than let Prometheus write when the data was scraped for that
+                metric.
               type: boolean
         status:
           description: Status results of an instance of Smart Gateway
@@ -102,14 +109,25 @@ spec:
               description: The resulting conditions when a Smart Gateway is instantiated
               items:
                 properties:
+                  lastTransitionTime:
+                    type: string
+                  reason:
+                    type: string
                   status:
                     type: string
                   type:
                     type: string
-                  reason:
-                    type: string
-                  lastTransitionTime:
-                    type: string
                 type: object
               type: array
           type: object
+  version: v2alpha1
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/deploy/olm-catalog/smart-gateway-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/metadata/annotations.yaml
@@ -1,7 +1,10 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: latest
+  operators.operatorframework.io.bundle.channels.v1: latest
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: smart-gateway-operator
+  operators.operatorframework.io.metrics.builder: operator-sdk-v0.19.4
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: ansible


### PR DESCRIPTION
Migrate to the 'latest' channel (same as Service Telemetry Operator) by default. These changes
were done by the 0.19.4 version of operator-sdk via the following command:

operator-sdk generate bundle --channels latest --default-channel latest
