### PR TITLE
Fix ES authentication bug, add sg shortname

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=smart-gateway-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=unstable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=unstable
-LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
+LABEL operators.operatorframework.io.metrics.project_layout=ansible
 
 COPY deploy/olm-catalog/smart-gateway-operator/manifests /manifests/
 COPY deploy/olm-catalog/smart-gateway-operator/metadata /metadata/

--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -9,6 +9,8 @@ spec:
     listKind: SmartGatewayList
     plural: smartgateways
     singular: smartgateway
+    shortNames:
+    - sg
   scope: Namespaced
   version: v2alpha1
   subresources:

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -9,6 +9,8 @@ spec:
     kind: SmartGateway
     listKind: SmartGatewayList
     plural: smartgateways
+    shortNames:
+    - sg
     singular: smartgateway
   scope: Namespaced
   subresources:

--- a/roles/smartgateway/templates/sg-core-configmap.yaml.j2
+++ b/roles/smartgateway/templates/sg-core-configmap.yaml.j2
@@ -35,7 +35,7 @@ data:
           useBasicAuth: {{ use_basic_auth | default('false') | lower }}
           hostURL: {{ elastic_url | default('http://elasticsearch.' + meta.namespace + '.svc:9200') }}
           user: {{ elastic_user | default('elastic') }}
-          password: {{ elastic_user | default('changeme') }}
+          password: {{ elastic_pass | default('changeme') }}
           useTLS: {{ use_tls | default('false') | lower }}
           tlsServerName: {{ tls_server_name | default('') }}
           tlsClientCert: {{ tls_client_cert | default('') }}


### PR DESCRIPTION
Fix problem with sg-core ES authentication configuration.

I am sneaking the short name 'sg' for the smartgateway CRs as well