### PR TITLE
Update the demo metrics cr

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_v2_smartgateway.metrics_cr.yaml
+++ b/deploy/crds/smartgateway.infra.watch_v2_smartgateway.metrics_cr.yaml
@@ -10,11 +10,11 @@ spec:
   bridge:
     enabled: true
     amqpUrl: "amqp://amq-interconnect:5672/collectd"
-    unix_socket_path: "/tmp/smartgateway"
-    socket_block: true
-    ring_buffer_count: 15000
-    stats_period: 60
-    stop_count: 0
+    unixSocketPath: "/tmp"
+    socketBlock: true
+    ringBufferCount: 15000
+    statsPeriod: 60
+    stopCount: 0
     verbose: true
   services:
     - name: prometheus


### PR DESCRIPTION
I noticed a few minor issues in the metrics cr and thought it would be cool to have it functional.

If I'm correct, the options for bridge should all be camel case.
I changed the socket path for bridge to point to the same location as the socket transport plugin in sg-core. (The "/smartgateway" is appended later elsewhere by the operator).

I didn't actually test the whole cr, because I don't have prometheus or collectd deployed anywhere.