### PR TITLE
Default RB size to be rsyslog omamqp1 compatible

### DIFF
--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -17,6 +17,7 @@ sg_defaults:
     unix_socket_path: "/tmp"
     socket_block: true
     ring_buffer_count: 15000
+    ring_buffer_size: 135048
     stats_period: 60
     stop_count: 0
     verbose: true


### PR DESCRIPTION
The ring buffer size defaults to 2048 [1] but testing[2] shows that much larger messages[3] can show up when using rsyslog. Setting this to twice the max observed value to be safe because it seems the more volume I pushed in the more it wanted to creep upwards. We may need to revisit when the real bench-marking begins.

Note that this results in a ring buffer that consumes ~2G of heap space (135048 * 15000). I think the 15000 is overkill in terms of actual ring buffer usage, but it may also affect the amqp link credit calculations and could still need to be 15000 for metrics. It's worth checking if we can use smaller values for both of whether they should be configured differently.

[1] https://github.com/infrawatch/sg-bridge/blob/master/bridge.h#L25
[2] https://github.com/infrawatch/sg-bridge/blob/csibbitt-hacking/socket_snd_th.c#L178
[3] `Calling pn_message_decode with size: 67524`