### PR TITLE
    Bump OCP installable version to include v4.7

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
+++ b/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.5-v4.6"
+LABEL com.redhat.openshift.versions="v4.6-v4.7"
 LABEL com.redhat.delivery.backport=true
 
 LABEL com.redhat.component="smart-gateway-operator-bundle-container" \


### PR DESCRIPTION
    Bump bundle so that OCP 4.6 and 4.7 are available for STF installation.

    Resolves: rhbz#1975792

Signed-off-by: Leif Madsen <lmadsen@redhat.com>
