### PR TITLE
Fix error in bundle Dockerfile

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
+++ b/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
@@ -12,9 +12,9 @@ LABEL operators.operatorframework.io.bundle.channel.default.v1=<<BUNDLE_DEFAULT_
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
-LABEL com.redhat.delivery.operator.bundle=false
+LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions="v4.6-v4.7"
-LABEL com.redhat.delivery.backport=true
+LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="smart-gateway-operator-bundle-container" \
       name="stf/smart-gateway-operator-bundle" \


### PR DESCRIPTION
Fix an error introduced in 458acc610098cd18715b3d3334124f2264d34833 which results in the Dockerfile
template for the bundle being invalid. Wrong LABEL was changed, and this commit resolves the error.
