### PR TITLE
 Token auth implementation for SG metrics endpoint

### DIFF
--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -10,6 +10,9 @@ exporter_host: 0.0.0.0
 exporter_port: 8081
 block_event_bus: false
 
+# - This image works on OCP 4.6, 4.7, and 4.8
+oauth_proxy_image: image-registry.openshift-image-registry.svc:5000/openshift/oauth-proxy:v4.4
+
 # used in conjunction with sg_vars in vars/main.yml to provide single parameter override for the dictionaries
 sg_defaults:
   bridge:

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -23,6 +23,27 @@
     bridge_container_image_path: "{{ lookup('env', 'RELATED_IMAGE_BRIDGE_SMARTGATEWAY_IMAGE') | default('quay.io/infrawatch/sg-bridge:latest', true) }}"
   when: bridge_container_image_path is undefined
 
+- name: Check for existing cookie secret
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: '{{ meta.namespace }}'
+    name: 'smart-gateway-session-secret'
+  register: session_secret
+
+- name: Create cookie secret
+  no_log: true
+  k8s:
+    definition:
+      api_version: v1
+      kind: Secret
+      metadata:
+        name: 'smart-gateway-session-secret'
+        namespace: '{{ meta.namespace }}'
+      stringData:
+        session_secret: "{{ lookup('password', '/dev/null') }}"
+  when: session_secret.resources|length == 0
+
 # used as part of the Deployment object in order to trigger pod restarts on ConfigMap change
 - name: Get Smart Gateway ConfigMap Environment
   set_fact:

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -26,6 +26,26 @@ spec:
 {% endif %}
     spec:
       containers:
+{% if (applications | selectattr('name','equalto','prometheus') | list | count > 0) %}
+      - name: oauth-proxy
+        image: {{ oauth_proxy_image }}
+        args:
+        - -https-address=:8083
+        - -tls-cert=/etc/tls/private/tls.crt
+        - -tls-key=/etc/tls/private/tls.key
+        - -cookie-secret-file=/etc/proxy/secrets/session_secret
+        - -openshift-service-account=NA
+        - -upstream=http://localhost:8081/
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+        ports:
+        - containerPort: 8083
+          name: https
+        volumeMounts:
+          - mountPath: /etc/tls/private
+            name: {{ meta.name }}-proxy-tls
+          - mountPath: /etc/proxy/secrets
+            name: session-secret
+{% endif -%}
 {% if sg_vars.bridge.enabled is defined and sg_vars.bridge.enabled %}
       - name: bridge
         image: {{ bridge_container_image_path }}
@@ -117,6 +137,12 @@ spec:
 {%   endif %}
 {% endif %}
       volumes:
+{% if (applications | selectattr('name','equalto','prometheus') | list | count > 0) %}
+      - name: {{ meta.name }}-proxy-tls
+        secret:
+          defaultMode: 420
+          secretName: {{ meta.name }}-proxy-tls
+{% endif %}
       - name: socket-dir
         emptyDir: {}
 {% if smartgateway_resource_configmap is defined %}
@@ -129,4 +155,7 @@ spec:
         secret:
           secretName: {{ tls_secret_name }}
 {% endif %}
+      - name: session-secret
+        secret:
+          secretName: smart-gateway-session-secret
 # vim: set ft=yaml shiftwidth=2 tabstop=2 expandtab:

--- a/roles/smartgateway/templates/service.yaml.j2
+++ b/roles/smartgateway/templates/service.yaml.j2
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: '{{ this_service.name }}'
   namespace: '{{ meta.namespace }}'
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ this_service.name }}-proxy-tls
   labels:
     app: smart-gateway
     smart-gateway: '{{ meta.name }}'


### PR DESCRIPTION
* Uses oauth-proxy
  * I also tried kube-rbac-proxy, but the oauth-proxy image is already in OCP
  * Interactive login is disabled, it would require a lot more permissions and
   publicly facing routes for every SG