### PR TITLE
Use correct type for blockEventBus

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -49,7 +49,7 @@ spec:
                 type: string
               blockEventBus:
                 description: Enables event bus blocking for sg-core. Defaults to false.
-                type: string
+                type: boolean
               size:
                 description: Number of Smart Gateway instances to deploy. This number should always be a value of 1.
                 type: integer

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -52,7 +52,7 @@ spec:
                 type: array
               blockEventBus:
                 description: Enables event bus blocking for sg-core. Defaults to false.
-                type: string
+                type: boolean
               bridge:
                 description: AMQP1 bridge configuration options
                 properties:


### PR DESCRIPTION
This is needed to be able to use the blockEventBus. The operator complained for using incorrect type when trying to use "true" as a string.