### PR TITLE
Test via molecule with KinD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,28 @@ name: CI
 on: push
 
 jobs:
+  molecule:
+    name: Molecule testing with KinD
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install local kustomize path
+        run: make kustomize-local
+
+      - name: Install base dependencies
+        run: python -m pip install ansible kubernetes openshift molecule docker
+
+      - name: Install KinD
+        run: sudo curl -Lo /usr/bin/kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 ; sudo chmod +x /usr/bin/kind
+
+      - name: Install Ansible dependencies from requirements.yml
+        run: ansible-galaxy collection install -r requirements.yml
+
+      - name: Run molecule test
+        run: KUSTOMIZE_PATH="$(pwd)/bin/kustomize" molecule test -s kind
+
   ansible-linting:
     name: Basic Ansible Linting
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,20 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/')
 
+.PHONY: kustomize-local
+KUSTOMIZE_LOCAL = $(shell pwd)/bin/kustomize
+kustomize-local: ## Download kustomize locally if necessary.
+ifeq (,$(wildcard $(KUSTOMIZE_LOCAL)))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(KUSTOMIZE_LOCAL)) ;\
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.7/kustomize_v3.8.7_$(OS)_$(ARCH).tar.gz | \
+	tar xzf - -C bin/ ;\
+	}
+else
+KUSTOMIZE_LOCAL = $(shell which kustomize)
+endif
+
 .PHONY: kustomize
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/config/crd/bases/smartgateway.infra.watch_smartgateways.yaml
+++ b/config/crd/bases/smartgateway.infra.watch_smartgateways.yaml
@@ -56,6 +56,9 @@ spec:
               handleErrors:
                 description: Tell handlers to send errors to event bus.
                 type: boolean
+              oauthProxyImage:
+                description: OAuth proxy container image.
+                type: string
               bridgeContainerImagePath:
                 description: Registry path to bridge container image.
                 type: string

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: smart-gateway-operator-system
+namespace: service-telemetry
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/infrawatch/smart-gateway-operator
-  newTag: 5.0.0
+  newTag: 5.0.0-dev5

--- a/config/samples/smartgateway_v2_smartgateway.yaml
+++ b/config/samples/smartgateway_v2_smartgateway.yaml
@@ -3,6 +3,7 @@ kind: SmartGateway
 metadata:
   name: smartgateway-sample
 spec:
+  oauthProxyImage: quay.io/openshift/origin-oauth-proxy:4.4
   applications:
     - config: |
         host: 127.0.0.1

--- a/config/testing/kustomization.yaml
+++ b/config/testing/kustomization.yaml
@@ -1,7 +1,7 @@
 # Adds namespace to all resources.
 namespace: osdk-test
 
-namePrefix: osdk-
+namePrefix: smart-gateway-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:
@@ -21,3 +21,5 @@ resources:
 images:
 - name: testing
   newName: testing-operator
+patches:
+- path: pull_policy/Never.yaml

--- a/molecule/default/tasks/smartgateway_test.yml
+++ b/molecule/default/tasks/smartgateway_test.yml
@@ -1,6 +1,29 @@
 ---
+- name: Generate an OpenSSL private key
+  community.crypto.openssl_privatekey:
+    path: /tmp/infra.watch.pem
+    size: 2048
+
+- name: Generate an OpenSSL Certificate Signing Request
+  community.crypto.openssl_csr:
+    path: /tmp/infra.watch.csr
+    privatekey_path: /tmp/infra.watch.pem
+    common_name: infra.watch
+
+- name: Generate self-signed certificate for smartgateway-sample-tls-proxy
+  community.crypto.x509_certificate:
+    path: /tmp/infra.watch.crt
+    privatekey_path: /tmp/infra.watch.pem
+    csr_path: /tmp/infra.watch.csr
+    provider: selfsigned
+
+- name: Create Secret from certificates
+  command: |
+    kubectl --namespace={{ namespace }} create secret tls smartgateway-sample-proxy-tls --namespace=osdk-test --cert=/tmp/infra.watch.crt --key=/tmp/infra.watch.pem
+  ignore_errors: yes
+
 - name: Create the smartgateway.infra.watch/v2.SmartGateway
-  k8s:
+  kubernetes.core.k8s:
     state: present
     namespace: '{{ namespace }}'
     definition: "{{ lookup('template', '/'.join([samples_dir, cr_file])) | from_yaml }}"
@@ -12,7 +35,11 @@
   vars:
     cr_file: 'smartgateway_v2_smartgateway.yaml'
 
-- name: Add assertions here
-  assert:
-    that: false
-    fail_msg: FIXME Add real assertions for your operator
+- debug: var=deploy
+  vars:
+    deploy: '{{ lookup("kubernetes.core.k8s", api_version="v1", kind="Deployment", namespace=namespace, resource_name="smartgateway-sample-smartgateway") }}'
+
+- assert:
+    that: deploy.status.readyReplicas > 0
+  vars:
+    deploy: '{{ lookup("kubernetes.core.k8s", api_version="v1", kind="Deployment", namespace=namespace, resource_name="smartgateway-sample-smartgateway") }}'

--- a/molecule/default/tasks/smartgateway_test.yml
+++ b/molecule/default/tasks/smartgateway_test.yml
@@ -19,7 +19,7 @@
 
 - name: Create Secret from certificates
   command: |
-    kubectl --namespace={{ namespace }} create secret tls smartgateway-sample-proxy-tls --namespace=osdk-test --cert=/tmp/infra.watch.crt --key=/tmp/infra.watch.pem
+    kubectl --namespace={{ namespace }} create secret tls smartgateway-sample-proxy-tls --cert=/tmp/infra.watch.crt --key=/tmp/infra.watch.pem
   ignore_errors: yes
 
 - name: Create the smartgateway.infra.watch/v2.SmartGateway

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,6 +5,7 @@
   gather_facts: no
   collections:
     - kubernetes.core
+    - community.crypto
 
   vars:
     ctrl_label: control-plane=controller-manager

--- a/molecule/kind/molecule.yml
+++ b/molecule/kind/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: delegated
 lint: |
   set -e
-  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 512}}}" .
 platforms:
   - name: cluster
     groups:

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,3 +6,4 @@ collections:
     version: "0.3.1"
   - name: kubernetes.core
     version: "2.2.0"
+  - name: community.crypto


### PR DESCRIPTION
Implement a basic molecule test with KinD in order to load the operator
and the workload, then perform a basic assertion test to verify that
everything is operational. More work will be required here as the test
is effectively a stub at this point.

In the molecule test needed to fake the creation of a TLS certificate
that is normally dealt with in OpenShift without this effort. Created a
locally self-signed certificate that is then loaded as the
smartgateway-sample-proxy-tls Secret that is mounted by the Smart
Gateway Deployment as a mounted volume for oauth-proxy.

In an OpenShift environment the oauth-proxy is available in the local
registry. Within a KinD environment that is not available. The existing
oauth_proxy_image path is defaulted in the role, but is now exposed as a
parameter to the SmartGateway custom resource. Because of the migration
to CRD/v1 unknown parameters are no longer preserved by default. This
new parameter is exposed primarily for testing but should be useful in
the future as well.

Adds another Makefile option called kustomize-local which doesn't have
the same checks as the standard kustomize command. In the testing
environment an incompatible version of kustomize may be installed, and
it's not always possible to remove it. Using kustomize-local results in
a specific kustomize version being added locally and then referenced by
the testing infrastructure for consistency.