### PR TITLE
Adjust cluster roles for oauth-proxy

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -69,8 +69,8 @@ metadata:
     createdAt: <<CREATED_DATE>>
     description: Operator for managing the Smart Gateway Custom Resources, resulting
       in deployments of the Smart Gateway.
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     olm.skipRange: =><<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>
-    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
     repository: https://github.com/infrawatch/smart-gateway-operator
@@ -127,6 +127,21 @@ spec:
     mediatype: image/svg+xml
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        serviceAccountName: smart-gateway-operator
       deployments:
       - name: smart-gateway-operator
         spec:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -78,3 +78,21 @@ rules:
   - patch
   - update
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: smart-gateway-operator
+rules:
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -17,6 +17,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: smart-gateway-operator
+  namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: smart-gateway-operator

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -9,3 +9,15 @@ roleRef:
   kind: Role
   name: smart-gateway-operator
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: smart-gateway-operator
+subjects:
+- kind: ServiceAccount
+  name: smart-gateway-operator
+roleRef:
+  kind: ClusterRole
+  name: smart-gateway-operator
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Adjust cluster roles for oauth-proxy and run operator-sdk generate bundle.
    
Import the new cluster role controls to the CSV by running `operator-sdk-0.19.4 generate bundle --channels unstable --default-channel unstable`