### PR TITLE
Adjust cluster roles for oauth-proxy (#110)

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,0 +1,2 @@
+skip_list:
+  - fqcn-builtins

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         run: ansible-galaxy collection install operator_sdk.util
 
       - name: Install ansible-lint
-        run: pip install ansible-lint
+        run: pip install ansible-lint 'ansible-lint < 6.0.0'
 
       - name: Lint Ansible roles/smartgateway/ directory
         run: ${HOME}/.local/bin/ansible-lint roles/smartgateway

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ansible
-        run: python -m pip install ansible
+        run: python -m pip install 'ansible <= 2.9'
 
       - name: Install operator_sdk.util dependency for Ansible role linting
         run: ansible-galaxy collection install operator_sdk.util

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         run: ansible-galaxy collection install operator_sdk.util
 
       - name: Install ansible-lint
-        run: pip install ansible-lint 'ansible-lint < 6.0.0'
+        run: pip install 'ansible-lint < 6.0.0'
 
       - name: Lint Ansible roles/smartgateway/ directory
         run: ${HOME}/.local/bin/ansible-lint roles/smartgateway

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -69,8 +69,8 @@ metadata:
     createdAt: <<CREATED_DATE>>
     description: Operator for managing the Smart Gateway Custom Resources, resulting
       in deployments of the Smart Gateway.
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     olm.skipRange: =><<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>
-    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
     repository: https://github.com/infrawatch/smart-gateway-operator
@@ -127,6 +127,21 @@ spec:
     mediatype: image/svg+xml
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        serviceAccountName: smart-gateway-operator
       deployments:
       - name: smart-gateway-operator
         spec:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -78,3 +78,21 @@ rules:
   - patch
   - update
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: smart-gateway-operator
+rules:
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -9,3 +9,16 @@ roleRef:
   kind: Role
   name: smart-gateway-operator
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: smart-gateway-operator
+subjects:
+- kind: ServiceAccount
+  name: smart-gateway-operator
+  namespace: placeholder
+roleRef:
+  kind: ClusterRole
+  name: smart-gateway-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/smartgateway/vars/main.yml
+++ b/roles/smartgateway/vars/main.yml
@@ -7,4 +7,3 @@ sg_vars:
     {%- else -%}
     {{ sg_defaults.bridge }}
     {%- endif -%}
-


### PR DESCRIPTION
* Adjust cluster roles for oauth-proxy

Adjust cluster roles for oauth-proxy and run operator-sdk generate
bundle.

Import the new cluster role controls to the CSV by running
operator-sdk-0.19.4 generate bundle --channels unstable
--default-channel unstable

* Add placeholder namespace for cluster role

Cherry picked from commit 0d86e03a6d850ce169a32740c04027f43bb1f9db
