### PR TITLE
Fix linting by locking versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ansible
-        run: python -m pip install ansible
+        run: python -m pip install 'ansible <= 2.9'
 
       - name: Install operator_sdk.util dependency for Ansible role linting
         run: ansible-galaxy collection install operator_sdk.util
 
       - name: Install ansible-lint
-        run: pip install ansible-lint
+        run: pip install 'ansible-lint < 6.0.0'
 
       - name: Lint Ansible roles/smartgateway/ directory
         run: ${HOME}/.local/bin/ansible-lint roles/smartgateway

--- a/roles/smartgateway/vars/main.yml
+++ b/roles/smartgateway/vars/main.yml
@@ -7,4 +7,3 @@ sg_vars:
     {%- else -%}
     {{ sg_defaults.bridge }}
     {%- endif -%}
-


### PR DESCRIPTION
Lock versions installed as part of the CI linting system as new rules
existing for newer Ansible Runner versions (which we're not using).
