### PR TITLE
Create separate ServiceAccount for Smart Gateways

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -127,6 +127,78 @@ spec:
     mediatype: image/svg+xml
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - create
+          - list
+          - get
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - list
+          - get
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - list
+          - get
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        serviceAccountName: smart-gateway-operator
       deployments:
       - name: smart-gateway-operator
         spec:
@@ -186,6 +258,7 @@ spec:
           - events
           - configmaps
           - secrets
+          - serviceaccounts
           verbs:
           - create
           - delete
@@ -248,6 +321,28 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - get
+          - list
           - watch
         serviceAccountName: smart-gateway-operator
     strategy: deployment

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,7 +1,81 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: smart-gateway-operator
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - list
+  - get
+  - update
+  - patch
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - list
+  - get
+  - update
+  - patch
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - list
+  - get
+  - update
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: smart-gateway-operator
 rules:
 - apiGroups:
@@ -15,6 +89,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - create
   - delete
@@ -78,3 +153,26 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,3 +1,16 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: smart-gateway-operator
+subjects:
+- kind: ServiceAccount
+  name: smart-gateway-operator
+  namespace: service-telemetry
+roleRef:
+  kind: ClusterRole
+  name: smart-gateway-operator
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -9,16 +22,3 @@ roleRef:
   kind: Role
   name: smart-gateway-operator
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: smart-gateway-auth-delegator
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: placeholder
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator

--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -9,6 +9,7 @@ tls_secret_name: elasticsearch-es-cert
 exporter_host: 0.0.0.0
 exporter_port: 8081
 block_event_bus: false
+service_account_name: smart-gateway
 
 # - This image works on OCP 4.6, 4.7, and 4.8
 oauth_proxy_image: image-registry.openshift-image-registry.svc:5000/openshift/oauth-proxy:v4.4

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -44,6 +44,41 @@
         session_secret: "{{ lookup('password', '/dev/null') }}"
   when: session_secret.resources|length == 0
 
+- name: Create Smart Gateway ServiceAccount
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ service_account_name }}"
+        namespace: "{{ meta.namespace }}"
+
+- name: Create Smart Gateway Role
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'sg-role.yaml.j2') | from_yaml }}"
+
+- name: Create Smart Gateway RoleBinding
+  k8s:
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        labels:
+          app.kubernetes.io/component: smart-gateway
+          app.kubernetes.io/name: smart-gateway
+          app.kubernetes.io/part-of: service-telemetry-framework
+        name: smart-gateway
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: smart-gateway
+      subjects:
+      - kind: ServiceAccount
+        name: smart-gateway
+        namespace: "{{ meta.namespace }}"
+
 # used as part of the Deployment object in order to trigger pod restarts on ConfigMap change
 - name: Get Smart Gateway ConfigMap Environment
   set_fact:

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -34,7 +34,7 @@ spec:
         - -tls-cert=/etc/tls/private/tls.crt
         - -tls-key=/etc/tls/private/tls.key
         - -cookie-secret-file=/etc/proxy/secrets/session_secret
-        - -openshift-service-account=NA
+        - -openshift-service-account={{ service_account_name }}
         - -upstream=http://localhost:8081/
         - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
         ports:
@@ -136,6 +136,7 @@ spec:
 {%     endfor %}
 {%   endif %}
 {% endif %}
+      serviceAccountName: {{ service_account_name }}
       volumes:
 {% if (applications | selectattr('name','equalto','prometheus') | list | count > 0) %}
       - name: {{ meta.name }}-proxy-tls

--- a/roles/smartgateway/templates/sg-role.yaml.j2
+++ b/roles/smartgateway/templates/sg-role.yaml.j2
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: smart-gateway
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create


### PR DESCRIPTION
Create a separate ServiceAccount for use by the Smart Gateway workloads.
This requires changes to the Operator RBAC permissions so that it can
create ClusterRoles, ClusterRoleBindings, and ServiceAcccounts.

Implement Ansible changes to the smartgateway role so that the
appropriate resources are created in the cluster, and assigned the RBAC
permissions to the Smart Gateway workload. Move the Deployment of Smart
Gateways from using the default ServiceAccount, and instead use the new
smart-gateway ServiceAccount.