### PR TITLE
Set placeholder namespace in role_binding.yaml

### DIFF
--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: smart-gateway-operator
-  namespace: service-telemetry
+  namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: smart-gateway-operator


### PR DESCRIPTION
Set the namespace to 'placeholder' as expected by CI due to dynamic
namespace usage. This was accidentially changed during the work in #119.