### PR TITLE
Set placeholder namespace in role_binding.yaml (#121)

### DIFF
--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: smart-gateway-operator
-  namespace: service-telemetry
+  namespace: placeholder
 roleRef:
   kind: ClusterRole
   name: smart-gateway-operator


### PR DESCRIPTION
Set the namespace to 'placeholder' as expected by CI due to dynamic
namespace usage. This was accidentially changed during the work in #119.

Cherry picked from commit fde553c410ea751d3795734d85adb72cf34bc882
