### PR TITLE
Base changes to allow deployment on OCP v4.10

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
+++ b/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.7-v4.8"
+LABEL com.redhat.openshift.versions="v4.10"
 LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="smart-gateway-operator-bundle-container" \

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -69,7 +69,7 @@ metadata:
     createdAt: <<CREATED_DATE>>
     description: Operator for managing the Smart Gateway Custom Resources, resulting
       in deployments of the Smart Gateway.
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.10"}]'
     olm.skipRange: =><<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
@@ -370,7 +370,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: stable
-  minKubeVersion: 1.20.0
+  minKubeVersion: 1.23.0
   provider:
     name: Red Hat
   selector:


### PR DESCRIPTION
Base changes to allow the Operator to be deployed on OCP v4.10. Does not include any changes or testing for operation on v4.10, but rather updates the metadata to allow it to be displayed in OLM on an OCP v4.10 deployment.