### PR TITLE
Fix the valid-subscription annotation

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -73,6 +73,8 @@ metadata:
     olm.skipRange: =><<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
     operators.operatorframework.io/project_layout: ansible
+    operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",
+      "Cloud Suite"]'
     repository: https://github.com/infrawatch/smart-gateway-operator
     support: Red Hat
   name: smart-gateway-operator.v1.99.0


### PR DESCRIPTION
Causes the subscription annotation to match STO. After these changes merge and are imported downstream, comet will need to be adjusted for the SGO bundle.