### PR TITLE
GHA checkout action v2 is deprecated (#135)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Ansible
         run: python -m pip install 'ansible <= 2.9'
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Verify image builds
         run: docker build --tag infrawatch/smart-gateway-operator:latest --file build/Dockerfile .
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get operator-sdk image
         run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk-$RELEASE_VERSION-x86_64-linux-gnu


### PR DESCRIPTION
The GitHub Actions checkout action v2 is deprecated and needs to move to
version 3.

(cherry picked from commit df23d639c878ac6b4ecdfdd38003042ee07dd208)
