### PR TITLE
Honor tlsSecretName from ES application config

### DIFF
--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -154,7 +154,7 @@ spec:
 {% if (applications | selectattr('name','equalto','elasticsearch') | list | count > 0) %}
       - name: elastic-certs
         secret:
-          secretName: {{ tls_secret_name }}
+          secretName: {{ (applications | selectattr('name','equalto','elasticsearch') | map(attribute='config') | first | from_yaml).tlsSecretName | default(tls_secret_name)}}
 {% endif %}
       - name: session-secret
         secret:


### PR DESCRIPTION
Currently we set a default tls_secret_name in the role, but have no way of supplying an override in the SmartGateway object. Adding it to the CRD seemed out of place because it's really only used for Elasticsearch, so I added it to the "freeform application config" that STO constructs for Elasticsearch[1]. This change allows the new config item to be honored, falling back to the existing default if it's not there. It feels a bit strange because that config is otherwise passed directly into sg-core, and this is only used by the operator, but this still seemed like the only logical place to add it.

[1] https://github.com/infrawatch/service-telemetry-operator/pull/439/files#diff-b661f3e2be8a3856711ae0ed99adda16e30a66a972ec5dc5118f57bfbf3ffe2dR22 