### PR TITLE
Bump origin-ansible-operator base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-ansible-operator:4.10
+FROM quay.io/openshift/origin-ansible-operator:4.12
 
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
Bump the origin-ansible-operator base image from 4.10 to 4.12.

Related STF-1524
