### PR TITLE
Add requires infrastructure annotations

### DIFF
--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -34,6 +34,18 @@ generate_bundle() {
     popd > /dev/null 2>&1
 
     sed -i -E "${REPLACE_REGEX}" "${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
+    cat >> "${WORKING_DIR}/metadata/annotations.yaml" << EOF
+  features.operators.openshift.io/disconnected: "false"
+  features.operators.openshift.io/fips-compliant: "false"
+  features.operators.openshift.io/proxy-aware: "false"
+  features.operators.openshift.io/cnf: "false"
+  features.operators.openshift.io/cni: "false"
+  features.operators.openshift.io/csi: "false"
+  features.operators.openshift.io/tls-profiles: "false"
+  features.operators.openshift.io/token-auth-aws: "false"
+  features.operators.openshift.io/token-auth-azure: "false"
+  features.operators.openshift.io/token-auth-gcp: "false"
+EOF
 }
 
 copy_extra_metadata() {

--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -34,18 +34,6 @@ generate_bundle() {
     popd > /dev/null 2>&1
 
     sed -i -E "${REPLACE_REGEX}" "${WORKING_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"
-    cat >> "${WORKING_DIR}/metadata/annotations.yaml" << EOF
-  features.operators.openshift.io/disconnected: "false"
-  features.operators.openshift.io/fips-compliant: "false"
-  features.operators.openshift.io/proxy-aware: "false"
-  features.operators.openshift.io/cnf: "false"
-  features.operators.openshift.io/cni: "false"
-  features.operators.openshift.io/csi: "false"
-  features.operators.openshift.io/tls-profiles: "false"
-  features.operators.openshift.io/token-auth-aws: "false"
-  features.operators.openshift.io/token-auth-azure: "false"
-  features.operators.openshift.io/token-auth-gcp: "false"
-EOF
 }
 
 copy_extra_metadata() {

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -69,21 +69,21 @@ metadata:
     createdAt: <<CREATED_DATE>>
     description: Operator for managing the Smart Gateway Custom Resources, resulting
       in deployments of the Smart Gateway.
-    olm.skipRange: =><<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>
-    operators.operatorframework.io/builder: operator-sdk-v0.19.4
-    operators.operatorframework.io/project_layout: ansible
-    operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",
-      "Cloud Suite"]'
-    features.operators.openshift.io/disconnected: "false"
-    features.operators.openshift.io/fips-compliant: "false"
-    features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: =><<BUNDLE_OLM_SKIP_RANGE_LOWER_BOUND>> <<<OPERATOR_BUNDLE_VERSION>>
+    operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",
+      "Cloud Suite"]'
+    operators.operatorframework.io/builder: operator-sdk-v0.19.4
+    operators.operatorframework.io/project_layout: ansible
     repository: https://github.com/infrawatch/smart-gateway-operator
     support: Red Hat
   name: smart-gateway-operator.v1.99.0

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -74,6 +74,16 @@ metadata:
     operators.operatorframework.io/project_layout: ansible
     operators.openshift.io/valid-subscription: '["OpenStack Platform", "Cloud Infrastructure",
       "Cloud Suite"]'
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://github.com/infrawatch/smart-gateway-operator
     support: Red Hat
   name: smart-gateway-operator.v1.99.0


### PR DESCRIPTION
Add required infrastructure annotations for the bundle. Implementation
is done in generate_bundle.sh because the annotations.yaml file in the
deploy/olm-catalog/ directory is not read by operator-sdk-0.19.4. Append
required additional feature annotations to the generated
annotations.yaml by operator-sdk generate bundle.

Related STF-1530
