### PR TITLE
Next release of STF will start at OCP 4.11

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
+++ b/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.10-v4.14"
+LABEL com.redhat.openshift.versions="v4.11-v4.14"
 LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="smart-gateway-operator-bundle-container" \


### PR DESCRIPTION
Support STF 1.5 from OCP 4.11 through 4.14 for the next release as OCP 4.10 is now EOL.
