### PR TITLE
Update base image to pass security scans

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,16 @@
 FROM quay.io/openshift/origin-ansible-operator:4.12
 
+# temporarily switch to root user to adjust image layers
 USER 0
+
+# update the base image to allow forward-looking optimistic updates during the testing phase, with the added benefit of helping move closer to passing security scans.
+# -- excludes ansible so it remains at 2.9 tag as shipped with the base image
+# -- cleans up the cached data from dnf to keep the image as small as possible
 RUN dnf update -y --exclude=ansible* && dnf clean all && rm -rf /var/cache/dnf
 
+# switch back to user 1001 when running the base image (non-root)
 USER 1001
+
+# copy in required artifacts for the operator
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,8 @@
 FROM quay.io/openshift/origin-ansible-operator:4.12
 
+USER 0
+RUN dnf update -y --exclude=ansible* && dnf clean all && rm -rf /var/cache/dnf
+
+USER 1001
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
Update the base image with a dnf update (need to excluse ansible because
ansible updates aren't compatible with the current build). This keeps
packages up to date to allow the resulting image to pass registry
security scans.
