### PR TITLE
Support OCP v4.12 through v4.14

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
+++ b/deploy/olm-catalog/smart-gateway-operator/Dockerfile.in
@@ -13,7 +13,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v0.19.4
 LABEL operators.operatorframework.io.metrics.project_layout=ansible
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.11-v4.14"
+LABEL com.redhat.openshift.versions="v4.12-v4.14"
 LABEL com.redhat.delivery.backport=false
 
 LABEL com.redhat.component="smart-gateway-operator-bundle-container" \


### PR DESCRIPTION
Support STF 1.5.3 starting at OpenShift version 4.12 due to
incompatibility with 4.11 due to dependency requirements. Our primary
target is support of OCP EUS releases.

Related: STF-1632
(cherry picked from 9217763ef0c3c319341dc181e2fed5ef498d3de6)
