### PR TITLE
Bump actions checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
 
       - name: Install Ansible
         run: python -m pip install 'ansible <= 2.9'
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
 
       - name: Verify image builds
         run: docker build --tag infrawatch/smart-gateway-operator:latest --file build/Dockerfile .
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
 
       - name: Get operator-sdk image 0.19.4
         run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk-$RELEASE_VERSION-x86_64-linux-gnu
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
 
       # prepare environment to buld the bundle
       - name: Get operator-sdk image 0.19.4
@@ -104,7 +104,7 @@ jobs:
         run: operator-sdk-$RELEASE_VERSION bundle validate --verbose /tmp/bundle
 
       - name: Create KinD cluster to execute scorecard tests
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.10.0
 
       # perform scorecard checks against a KinD cluster
       - name: Check scorecord validation


### PR DESCRIPTION
Bump actions checkout to v4 since Node.js 16 actions are deprecated. We need to update to Node.js 20, which is included in actions/checkout@v4.

Also bumped helm kind-action to v1.10.0.