### PR TITLE
Update GH actions to use ubuntu-latest

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,8 @@
+# This file contains ignores rule violations for ansible-lint
+roles/smartgateway/defaults/main.yml var-naming[no-role-prefix]
+roles/smartgateway/meta/main.yml schema[meta]
+roles/smartgateway/tasks/base_service.yml fqcn[action]
+roles/smartgateway/tasks/main.yml fqcn[action-core]
+roles/smartgateway/tasks/main.yml fqcn[action]
+roles/smartgateway/tasks/main.yml yaml[indentation]
+roles/smartgateway/vars/main.yml var-naming[no-role-prefix]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: push
 jobs:
   ansible-linting:
     name: Basic Ansible Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.3
@@ -23,7 +23,7 @@ jobs:
 
   build-operator-check:
     name: Build Operator check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -34,7 +34,7 @@ jobs:
 
   build-bundle-check:
     name: Build bundle check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: v0.19.4
 
@@ -62,7 +62,7 @@ jobs:
 
   check-bundle-validation-scorecard:
     name: Validate the generated bundle and perform scorecard checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: v1.26.0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.3
 
+      # Python version being set because of issue with Ubuntu permissions and versions of Python < 3.11 
+      - name: Set up Python
+        # This is the version of the action for setting up Python, not the Python version.
+        uses: actions/setup-python@v5
+        with:
+          # Set exact version of a Python version or can use '3.x'.
+          python-version: '3.12.8' 
+
       - name: Install Ansible
-        run: python -m pip install 'ansible <= 2.9'
+        run: pip install ansible
 
       - name: Install operator_sdk.util dependency for Ansible role linting
         run: ansible-galaxy collection install operator_sdk.util
 
       - name: Install ansible-lint
-        run: pip install 'ansible-lint < 6.0.0'
+        run: pip install ansible-lint==24.7.0
 
       - name: Lint Ansible roles/smartgateway/ directory
-        run: ${HOME}/.local/bin/ansible-lint roles/smartgateway
+        run: ansible-lint roles/smartgateway
 
   build-operator-check:
     name: Build Operator check


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.

Actions need to be updated to a newer version.

For some jobs we are already using ubuntu-latest, so use the same for the jobs using ubuntu20.04