### PR TITLE
bundle gen: allow passing in pre-generated bundle version (#174)

### DIFF
--- a/build/generate_bundle.sh
+++ b/build/generate_bundle.sh
@@ -75,7 +75,9 @@ build_bundle_instructions() {
 
 
 # generate templates
-generate_version
+if [[ -z "${OPERATOR_BUNDLE_VERSION}" ]]; then
+    generate_version
+fi
 create_working_dir
 generate_dockerfile
 generate_bundle


### PR DESCRIPTION
This improves our support for generating bundles as part of multistage container builds, as a single pre-generated bundle version can be fed into the generated bundle and into the bundle container labels.

RELDEL-7554

(cherry picked from commit 26c76b9a6173c81eb2ca0fd8ea7a0b4b8b37c666)