### PR TITLE
Update olm.maxOpenShiftVersion to 4.18

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/metadata/properties.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: "4.16"
+    value: "4.18"


### PR DESCRIPTION
olm.maxOpenShiftVersion in SGO should be 4.18 instead of 4.16

This wrongly set config is preventing STF users to easily perform upgrades to the latest OCP supported version

Closes-Bug: OSPRH-18670