### PR TITLE
Update ansible-lint pinned version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         run: ansible-galaxy collection install operator_sdk.util
 
       - name: Install ansible-lint
-        run: pip install ansible-lint==24.7.0
+        run: pip install ansible-lint==25.2.0
 
       - name: Lint Ansible roles/smartgateway/ directory
         run: ansible-lint roles/smartgateway


### PR DESCRIPTION
The version of ansible-lint is not compatible with the version of ansible-core we get in ubuntu-latest. Bump the version of ansible-lint to the next available version that fixes the issue.

https://github.com/ansible/ansible-lint/releases/tag/v25.2.0 fixes the issue.

Related Bug: OSPRH-20316