### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: CI
 on: push
+permissions:
+  contents: read
 
 jobs:
   ansible-linting:


### PR DESCRIPTION
Potential fix for [https://github.com/infrawatch/smart-gateway-operator/security/code-scanning/4](https://github.com/infrawatch/smart-gateway-operator/security/code-scanning/4)

To fix the problem, explicitly define a `permissions` block that grants only the minimal required access for this workflow. Since all jobs simply check out code, install tools, and run local commands with no apparent need to push changes, modify issues, or manage PRs, the minimal practical permissions are `contents: read`. Defining this at the top level of the workflow ensures all jobs inherit it, unless they later override it.

Concretely:

- In `.github/workflows/main.yml`, add a `permissions:` section near the top (after `name: CI` and before `on: push` or just after `on:`) specifying `contents: read`.
- This does not change any behavior for the existing steps, since all only require read access to the repository’s contents via `actions/checkout`.
- No new imports, methods, or external dependencies are needed; this is purely a YAML configuration change.

We only need to edit `.github/workflows/main.yml`, adding a small block and keeping the rest of the file intact.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
