### PR TITLE
Upgrade pyasn1 version to 0.6.3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,6 +8,9 @@ USER 0
 # -- cleans up the cached data from dnf to keep the image as small as possible
 RUN dnf update -y --exclude=ansible* && dnf clean all && rm -rf /var/cache/dnf
 
+# upgrade pyasn1 to fix CVE-2026-30922 (DoS vulnerability via unbounded recursion)
+RUN pip3 install --upgrade 'pyasn1>=0.6.3'
+
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible


### PR DESCRIPTION
The base ansible-operator:v1.38.1 image contains pyasn1 0.6.1, which is vulnerable to CVE-2026-30922

This change adds a pip3 upgrade step to install pyasn1>=0.6.3 which includes the MAX_NESTING_DEPTH protection against this attack.