### PR TITLE
Mark SGO as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # smart-gateway-operator
 
+> **⚠️ DEPRECATED**: This operator is deprecated and will no longer receive updates with new features. Changes in this repository are only related to maintenance tasks. Users should migrate to alternative telemetry solutions.
+
 Operator for the infra.watch [smart gateway](https://github.com/infrawatch/smart-gateway)
 
 ## Deployment to an existing cluster

--- a/catalog/smart-gateway-operator/deprecations.yaml
+++ b/catalog/smart-gateway-operator/deprecations.yaml
@@ -1,0 +1,9 @@
+---
+schema: olm.deprecations
+package: smart-gateway-operator
+entries:
+  - reference:
+      schema: olm.package
+    message: |
+      smart-gateway-operator is deprecated and future changes are limited to critical fixes.
+      Please migrate to alternative telemetry solutions.

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -67,8 +67,11 @@ metadata:
     certified: "false"
     containerImage: <<OPERATOR_IMAGE_PULLSPEC>>
     createdAt: <<CREATED_DATE>>
-    description: Operator for managing the Smart Gateway Custom Resources, resulting
-      in deployments of the Smart Gateway.
+    description: 'DEPRECATED: This operator is deprecated and will no longer receive
+      updates with new features. Users should migrate to alternative telemetry solutions.
+      Operator for managing the Smart Gateway Custom Resources, resulting in deployments
+      of the Smart Gateway.'
+    operators.operatorframework.io/deprecated: "true"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"


### PR DESCRIPTION
Add deprecation notices to indicate this operator will no longer receive feature updates.

Changes include CSV deprecated annotation, OLM deprecations file for OperatorHub warnings, and README deprecation banner.

Similar to https://github.com/infrawatch/service-telemetry-operator/pull/704