### PR TITLE
Restrict RBAC clusterroles/clusterrolebindings permissions

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -157,21 +157,17 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
-          - roles
-          verbs:
-          - create
-          - list
-          - get
-          - update
-          - patch
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
           - clusterroles
           verbs:
           - create
           - list
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          resourceNames:
+          - smart-gateway
+          verbs:
           - get
           - update
           - patch
@@ -183,6 +179,13 @@ spec:
           verbs:
           - create
           - list
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          resourceNames:
+          - smart-gateway
+          verbs:
           - get
           - update
           - patch

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -18,21 +18,17 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - roles
-  verbs:
-  - create
-  - list
-  - get
-  - update
-  - patch
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterroles
   verbs:
   - create
   - list
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  resourceNames:
+  - smart-gateway
+  verbs:
   - get
   - update
   - patch
@@ -44,6 +40,13 @@ rules:
   verbs:
   - create
   - list
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  resourceNames:
+  - smart-gateway
+  verbs:
   - get
   - update
   - patch


### PR DESCRIPTION
Scope get/update/patch/watch verbs on clusterroles and clusterrolebindings to resourceNames: [smart-gateway] to prevent write access to arbitrary cluster-wide RBAC objects. Remove unused roles write rule.