### PR TITLE
Add securityContext and resource limits to operator deployment

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -220,6 +220,10 @@ spec:
               labels:
                 app: smart-gateway-operator
             spec:
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               containers:
               - env:
                 - name: WATCH_NAMESPACE
@@ -247,14 +251,29 @@ spec:
                 image: <<OPERATOR_IMAGE_PULLSPEC>>
                 imagePullPolicy: Always
                 name: operator
-                resources: {}
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
                 volumeMounts:
-                - mountPath: /tmp/ansible-operator/runner
-                  name: runner
+                - mountPath: /tmp
+                  name: tmp
               serviceAccountName: smart-gateway-operator
               volumes:
               - emptyDir: {}
-                name: runner
+                name: tmp
       permissions:
       - rules:
         - apiGroups:

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -258,10 +258,10 @@ spec:
                 resources:
                   requests:
                     cpu: 100m
-                    memory: 256Mi
+                    memory: 512Mi
                   limits:
                     cpu: 500m
-                    memory: 512Mi
+                    memory: 1Gi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -226,6 +226,10 @@ spec:
                   type: RuntimeDefault
               containers:
               - env:
+                - name: ANSIBLE_LOCAL_TEMP
+                  value: /tmp/ansible-local
+                - name: ANSIBLE_REMOTE_TEMP
+                  value: /tmp/ansible-local
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,10 +33,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 512Mi
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
         volumeMounts:
         - mountPath: /tmp
           name: tmp

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -41,6 +41,10 @@ spec:
         - mountPath: /tmp
           name: tmp
         env:
+        - name: ANSIBLE_LOCAL_TEMP
+          value: /tmp/ansible-local
+        - name: ANSIBLE_REMOTE_TEMP
+          value: /tmp/ansible-local
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,14 +12,34 @@ spec:
       labels:
         app: smart-gateway-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: smart-gateway-operator
       containers:
       - name: operator
         image: <<OPERATOR_IMAGE_PULLSPEC>>
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
         volumeMounts:
-        - mountPath: /tmp/ansible-operator/runner
-          name: runner
+        - mountPath: /tmp
+          name: tmp
         env:
         - name: WATCH_NAMESPACE
           valueFrom:
@@ -45,4 +65,4 @@ spec:
           value: <<RELATED_IMAGE_OAUTH_PROXY_PULLSPEC>>
       volumes:
       - emptyDir: {}
-        name: runner
+        name: tmp


### PR DESCRIPTION
Add pod-level and container-level securityContext (runAsNonRoot, drop ALL capabilities, readOnlyRootFilesystem, RuntimeDefault seccomp) and define resource requests/limits.
Broaden the emptyDir mount from /tmp/ansible-operator/runner to /tmp so the ansible-operator can write temp files with readOnlyRootFilesystem enabled.

Closes: OSPRH-32350