### PR TITLE
Prevent container image injection via SmartGateway CR

### DIFF
--- a/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/crds/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -56,12 +56,6 @@ spec:
               handleErrors:
                 description: Tell handlers to send errors to event bus.
                 type: boolean
-              bridgeContainerImagePath:
-                description: Registry path to bridge container image.
-                type: string
-              coreContainerImagePath:
-                description: Registry path to the sg-core container image.
-                type: string
               bridge:
                 description: AMQP1 bridge configuration options
                 properties:

--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smartgateway.infra.watch_smartgateways_crd.yaml
@@ -106,12 +106,6 @@ spec:
                       Defaults to true.
                     type: boolean
                 type: object
-              bridgeContainerImagePath:
-                description: Registry path to bridge container image.
-                type: string
-              coreContainerImagePath:
-                description: Registry path to the sg-core container image.
-                type: string
               handleErrors:
                 description: Tell handlers to send errors to event bus.
                 type: boolean

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -16,12 +16,10 @@
 - name: Set Smart Gateway core image
   set_fact:
     core_container_image_path: "{{ lookup('env', 'RELATED_IMAGE_CORE_SMARTGATEWAY_IMAGE') | default('quay.io/infrawatch/sg-core:latest', true) }}"
-  when: core_container_image_path is undefined
 
 - name: Set Smart Gateway bridge image
   set_fact:
     bridge_container_image_path: "{{ lookup('env', 'RELATED_IMAGE_BRIDGE_SMARTGATEWAY_IMAGE') | default('quay.io/infrawatch/sg-bridge:latest', true) }}"
-  when: bridge_container_image_path is undefined
 
 - name: Set OAuth Proxy image
   set_fact:

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -45,6 +45,9 @@ spec:
             name: {{ ansible_operator_meta.name }}-proxy-tls
           - mountPath: /etc/proxy/secrets
             name: session-secret
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: sa-token
+            readOnly: true
 {% endif -%}
 {% if sg_vars.bridge.enabled is defined and sg_vars.bridge.enabled %}
       - name: bridge
@@ -137,6 +140,7 @@ spec:
 {%   endif %}
 {% endif %}
       serviceAccountName: {{ service_account_name }}
+      automountServiceAccountToken: false
       volumes:
 {% if (applications | selectattr('name','equalto','prometheus') | list | count > 0) %}
       - name: {{ ansible_operator_meta.name }}-proxy-tls
@@ -159,4 +163,22 @@ spec:
       - name: session-secret
         secret:
           secretName: smart-gateway-session-secret
+{% if (applications | selectattr('name','equalto','prometheus') | list | count > 0) %}
+      - name: sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 3600
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
+          - downwardAPI:
+              items:
+              - path: namespace
+                fieldRef:
+                  fieldPath: metadata.namespace
+{% endif %}
 # vim: set ft=yaml shiftwidth=2 tabstop=2 expandtab:


### PR DESCRIPTION
Prevent container image injection via SmartGateway CR (#194)

Remove coreContainerImagePath and bridgeContainerImagePath fields from CRD
schema. Operator environment variables (RELATED_IMAGE_*) now always control
container images - CR values can no longer override.

Add automountServiceAccountToken: false to pod spec. Mount projected SA token
only to oauth-proxy container (needs TokenReview/SAR for OpenShift auth).
bridge and sg-core containers run without cluster credentials.

Assisted-By: Claude 4.6

(cherry picked from commit 96da64916fa2b766662dce74c603432c96d8c14d)