### PR TITLE
Trigger CI on pull_request events (#195)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: CI
-on: push
+on:
+  push:
+    branches:
+      - master
+      - 'stable-*'
+  pull_request:
 
 jobs:
   ansible-linting:


### PR DESCRIPTION
The CI workflow only listens for push events, so it never runs for pull requests opened from forks (commits live on the fork branch, not in this repo). That leaves the branch's required status checks (Build Operator check, Build bundle check, bundle validation/scorecard, Ansible linting) permanently pending on fork PRs, blocking merge.

Add pull_request as a trigger so CI runs for PRs regardless of whether they come from a fork or a branch in this repo. None of the jobs use repository secrets, so pull_request (not pull_request_target) is safe here.

Scope push to master and stable-* release branches so same-repo PRs don't trigger CI twice (once for push, once for pull_request).

(cherry picked from commit 28f416359fb750707757dcb7dacfe52731466780)