### PR TITLE
Add securityContext and resource limits to operator deployment (#192)

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -220,8 +220,16 @@ spec:
               labels:
                 app: smart-gateway-operator
             spec:
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               containers:
               - env:
+                - name: ANSIBLE_LOCAL_TEMP
+                  value: /tmp/ansible-local
+                - name: ANSIBLE_REMOTE_TEMP
+                  value: /tmp/ansible-local
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -247,14 +255,29 @@ spec:
                 image: <<OPERATOR_IMAGE_PULLSPEC>>
                 imagePullPolicy: Always
                 name: operator
-                resources: {}
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
+                  limits:
+                    cpu: 500m
+                    memory: 1Gi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
                 volumeMounts:
-                - mountPath: /tmp/ansible-operator/runner
-                  name: runner
+                - mountPath: /tmp
+                  name: tmp
               serviceAccountName: smart-gateway-operator
               volumes:
               - emptyDir: {}
-                name: runner
+                name: tmp
       permissions:
       - rules:
         - apiGroups:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,15 +12,39 @@ spec:
       labels:
         app: smart-gateway-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: smart-gateway-operator
       containers:
       - name: operator
         image: <<OPERATOR_IMAGE_PULLSPEC>>
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
         volumeMounts:
-        - mountPath: /tmp/ansible-operator/runner
-          name: runner
+        - mountPath: /tmp
+          name: tmp
         env:
+        - name: ANSIBLE_LOCAL_TEMP
+          value: /tmp/ansible-local
+        - name: ANSIBLE_REMOTE_TEMP
+          value: /tmp/ansible-local
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
@@ -45,4 +69,4 @@ spec:
           value: <<RELATED_IMAGE_OAUTH_PROXY_PULLSPEC>>
       volumes:
       - emptyDir: {}
-        name: runner
+        name: tmp


### PR DESCRIPTION
* Add securityContext and resource limits to operator deployment

Add pod-level and container-level securityContext
(runAsNonRoot, drop ALL capabilities, readOnlyRootFilesystem, RuntimeDefault seccomp) and define resource requests/limits. Broaden the emptyDir mount from /tmp/ansible-operator/runner to /tmp so the ansible-operator can write temp files with readOnlyRootFilesystem enabled.

* Fix ansible-runner tmp dir failure under readOnlyRootFilesystem

The base ansible-operator image sets HOME=/opt/ansible, so ansible-playbook's default local/remote temp directory resolves to /opt/ansible/.ansible/tmp. With readOnlyRootFilesystem: true, only the emptyDir mounted at /tmp is writable, so every task failed immediately:

  [Errno 30] Read-only file system: '/opt/ansible/.ansible/tmp/...'

which crashed ansible-playbook before it could emit playbook_on_stats, breaking reconciliation for every SmartGateway CR.

Point ANSIBLE_LOCAL_TEMP/ANSIBLE_REMOTE_TEMP at a path under the writable /tmp mount instead of touching HOME, since HOME is also where the Ansible Galaxy collections were installed at build time.

* Raise operator memory limit to fix OOMKilled CrashLoopBackOff

The 512Mi memory limit added for this deployment was too tight for the ansible-operator process: each reconcile spawns an ansible-playbook subprocess (loading Ansible core, Jinja2, and installed collections), and ANSIBLE_DEBUG_LOGS/verbosity=4 add further overhead. The operator pod was hitting the limit and getting OOMKilled (exit 137) repeatedly, landing in CrashLoopBackOff and breaking reconciliation for every SmartGateway CR.

Bump requests to 512Mi/limits to 1Gi to give the process headroom.

---------

Closes: OSPRH-32350

(cherry picked from commit f26cea03a1fe950d4d048b99be9253f6dd138b43)