### PR TITLE
Add resource limits to Smart Gateway containers

### DIFF
--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -39,6 +39,13 @@ spec:
           capabilities:
             drop:
             - ALL
+        resources:
+          limits:
+            cpu: '2'
+            memory: 8Gi
+          requests:
+            cpu: 300m
+            memory: 512Mi
         args:
         - -https-address=:8083
         - -tls-cert=/etc/tls/private/tls.crt
@@ -80,6 +87,13 @@ spec:
           capabilities:
             drop:
             - ALL
+        resources:
+          limits:
+            cpu: '2'
+            memory: 8Gi
+          requests:
+            cpu: 300m
+            memory: 512Mi
         args:
 {%   if sg_vars.bridge.amqp_url is defined and sg_vars.bridge.amqp_url != "" %}
         - --amqp_url
@@ -137,6 +151,13 @@ spec:
           capabilities:
             drop:
             - ALL
+        resources:
+          limits:
+            cpu: '2'
+            memory: 8Gi
+          requests:
+            cpu: 300m
+            memory: 512Mi
         args:
           - -config
           - /etc/sg-core/sg-core.conf.yaml


### PR DESCRIPTION
Set CPU/memory requests and limits on all three containers (oauth-proxy, bridge, sg-core) in the generated Smart Gateway deployment to prevent unbounded resource consumption.

Related-To: OSPRH-32349
Related-To: OSPRH-33057