### PR TITLE
Add liveness and readiness probes to Smart Gateway containers

### DIFF
--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -50,6 +50,18 @@ spec:
         ports:
         - containerPort: 8083
           name: https
+        livenessProbe:
+          tcpSocket:
+            port: 8083
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 8083
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 10
         volumeMounts:
           - mountPath: /etc/tls/private
             name: {{ ansible_operator_meta.name }}-proxy-tls
@@ -160,6 +172,24 @@ spec:
 {%       endif %}
 {%     endfor %}
 {%   endif %}
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sf
+            - http://127.0.0.1:8081/metrics
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sf
+            - http://127.0.0.1:8081/metrics
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 10
 {% endif %}
       serviceAccountName: {{ service_account_name }}
       automountServiceAccountToken: false


### PR DESCRIPTION
Add tcpSocket probes for oauth-proxy (port 8083) and httpGet probes for sg-core (/metrics on port 8081). Bridge container has no health endpoint so probes are omitted there.

Assisted-By: Claude Opus 4.6

Related-To: OSPRH-32349