### PR TITLE
Scope sg-core probes to prometheus-enabled gateways

### DIFF
--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -172,6 +172,7 @@ spec:
 {%       endif %}
 {%     endfor %}
 {%   endif %}
+{%   if (applications | selectattr('name','equalto','prometheus') | list | count > 0) %}
         livenessProbe:
           exec:
             command:
@@ -190,6 +191,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 30
           timeoutSeconds: 10
+{%   endif %}
 {% endif %}
       serviceAccountName: {{ service_account_name }}
       automountServiceAccountToken: false


### PR DESCRIPTION
Event-type SmartGateways use elasticsearch and do not expose a metrics endpoint on port 8081, causing liveness probe failures. Wrap sg-core probes in a prometheus application conditional.

Post action after merging [1].

Related-To: OSPRH-32349

[1] https://github.com/infrawatch/smart-gateway-operator/pull/201