### PR TITLE
Add liveness probe 1.5

### DIFF
--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -150,6 +150,7 @@ spec:
 {%       endif %}
 {%     endfor %}
 {%   endif %}
+{%   if (applications | selectattr('name','equalto','prometheus') | list | count > 0) %}
         livenessProbe:
           exec:
             command:
@@ -168,6 +169,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 30
           timeoutSeconds: 10
+{%   endif %}
 {% endif %}
       serviceAccountName: {{ service_account_name }}
       automountServiceAccountToken: false

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -40,6 +40,18 @@ spec:
         ports:
         - containerPort: 8083
           name: https
+        livenessProbe:
+          tcpSocket:
+            port: 8083
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 8083
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 10
         volumeMounts:
           - mountPath: /etc/tls/private
             name: {{ ansible_operator_meta.name }}-proxy-tls
@@ -138,6 +150,24 @@ spec:
 {%       endif %}
 {%     endfor %}
 {%   endif %}
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sf
+            - http://127.0.0.1:8081/metrics
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sf
+            - http://127.0.0.1:8081/metrics
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 10
 {% endif %}
       serviceAccountName: {{ service_account_name }}
       automountServiceAccountToken: false


### PR DESCRIPTION
Add liveness and readiness probes to Smart Gateway containers (#201)

Add tcpSocket probes for oauth-proxy (port 8083) and httpGet
probes for sg-core (/metrics on port 8081). Bridge container
has no health endpoint so probes are omitted there.

Related-To: OSPRH-32349
(cherry picked from commit cf57e1a4f563d535a02516e6488add0119e7e8f0)
(cherry picked from commit 4e8299560294fc1c81b13fffaf830a03e839d52b)