### PR TITLE
Mark SmartGateway CR spec values as unsafe for Ansible templating

### DIFF
--- a/watches.yaml
+++ b/watches.yaml
@@ -3,3 +3,4 @@
   group: smartgateway.infra.watch
   kind: SmartGateway
   role: /opt/ansible/roles/smartgateway
+  markUnsafe: true


### PR DESCRIPTION
Set markUnsafe: true in watches.yaml so that CR spec fields are treated as literal strings during Ansible reconciliation, matching the recommended ansible-operator configuration for custom resources.