### PR TITLE
Mark SmartGateway CR spec values as unsafe for Ansible templating - 1.5

### DIFF
--- a/watches.yaml
+++ b/watches.yaml
@@ -3,3 +3,4 @@
   group: smartgateway.infra.watch
   kind: SmartGateway
   role: /opt/ansible/roles/smartgateway
+  markUnsafe: true


### PR DESCRIPTION
Set markUnsafe: true in watches.yaml so that CR spec fields are treated as literal strings during Ansible reconciliation, matching the recommended ansible-operator configuration for custom resources.

Related-To: OSPRH-32360

(cherry picked from commit 6806b4e2137d8dca8f23d44c086004fb81c82579)