### PR TITLE
Verify operator-sdk binary checksum in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: v1.39.2
+      OPERATOR_SDK_SHA256: 28fc8298a3202cb61fcae941e607f1cab705c9595ca9a7cf2d6d9f54a6b34641
 
     steps:
       - name: Checkout code
@@ -57,6 +58,9 @@ jobs:
 
       - name: Get operator-sdk image 1.39.2
         run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk_linux_amd64
+
+      - name: Verify operator-sdk checksum
+        run: echo "${OPERATOR_SDK_SHA256}  operator-sdk" | sha256sum -c -
 
       - name: Make operator-sdk executable
         run: chmod +x operator-sdk
@@ -78,6 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: v1.39.2
+      OPERATOR_SDK_SHA256: 28fc8298a3202cb61fcae941e607f1cab705c9595ca9a7cf2d6d9f54a6b34641
 
     steps:
       - name: Checkout code
@@ -88,6 +93,9 @@ jobs:
         run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk_linux_amd64
         env:
           RELEASE_VERSION: v1.39.2
+
+      - name: Verify operator-sdk checksum
+        run: echo "${OPERATOR_SDK_SHA256}  operator-sdk" | sha256sum -c -
 
       - name: Make operator-sdk executable
         run: chmod +x operator-sdk
@@ -105,6 +113,9 @@ jobs:
       # prepare the environment to run bundle validation and bundle scorecard checks
       - name: Get operator-sdk image 1.39.2
         run: curl --output operator-sdk-$RELEASE_VERSION -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk_linux_amd64
+
+      - name: Verify operator-sdk checksum
+        run: echo "${OPERATOR_SDK_SHA256}  operator-sdk-$RELEASE_VERSION" | sha256sum -c -
 
       - name: Make operator-sdk executable
         run: chmod +x operator-sdk-$RELEASE_VERSION


### PR DESCRIPTION
CI previously downloaded the operator-sdk binary from a GitHub release URL via plain curl and executed it without verifying integrity, letting a compromised or substituted release asset tamper with the generated bundle. Add a sha256sum check right after each download, using the checksum published in operator-sdk v1.39.2's checksums.txt.

Closes: OSPRH-32354