### PR TITLE
Pin GitHub Actions to commit SHA; restrict token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,18 +6,21 @@ on:
       - 'stable-*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ansible-linting:
     name: Basic Ansible Linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       # Python version being set because of issue with Ubuntu permissions and versions of Python < 3.11 
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           # Set exact version of a Python version or can use '3.x'.
           python-version: '3.12.8' 
@@ -40,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: Verify image builds
         run: docker build --tag infrawatch/smart-gateway-operator:latest --file build/Dockerfile .
@@ -54,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: Get operator-sdk image 1.39.2
         run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk_linux_amd64
@@ -86,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       # prepare environment to buld the bundle
       - name: Get operator-sdk image 1.39.2
@@ -128,7 +131,7 @@ jobs:
         run: operator-sdk-$RELEASE_VERSION bundle validate --verbose /tmp/bundle
 
       - name: Create KinD cluster to execute scorecard tests
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
 
       # perform scorecard checks against a KinD cluster
       - name: Check scorecord validation


### PR DESCRIPTION
Set SHA to Github module instead of tag version to prevent mutable tag compromise.
Also add top-level permissions: "contents: read" to restrict GITHUB_TOKEN scope to least privilege.

Related-To: OSPRH-32355