### PR TITLE
Reduce default verbosity

### DIFF
--- a/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/smart-gateway-operator/manifests/smart-gateway-operator.clusterserviceversion.yaml
@@ -243,9 +243,9 @@ spec:
                 - name: ANSIBLE_GATHERING
                   value: explicit
                 - name: ANSIBLE_VERBOSITY_SMARTGATEWAY_SMARTGATEWAY_INFRA_WATCH
-                  value: "4"
+                  value: "2"
                 - name: ANSIBLE_DEBUG_LOGS
-                  value: "true"
+                  value: "False"
                 - name: RELATED_IMAGE_CORE_SMARTGATEWAY_IMAGE
                   value: <<RELATED_IMAGE_CORE_SMARTGATEWAY_PULLSPEC>>
                 - name: RELATED_IMAGE_BRIDGE_SMARTGATEWAY_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -58,9 +58,9 @@ spec:
         - name: ANSIBLE_GATHERING
           value: explicit
         - name: ANSIBLE_VERBOSITY_SMARTGATEWAY_SMARTGATEWAY_INFRA_WATCH
-          value: 4
+          value: "2"
         - name: ANSIBLE_DEBUG_LOGS
-          value: true
+          value: "False"
         - name: RELATED_IMAGE_CORE_SMARTGATEWAY_IMAGE
           value: <<RELATED_IMAGE_CORE_SMARTGATEWAY_PULLSPEC>>
         - name: RELATED_IMAGE_BRIDGE_SMARTGATEWAY_IMAGE

--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -10,6 +10,7 @@ exporter_host: 0.0.0.0
 exporter_port: 8081
 block_event_bus: false
 service_account_name: smart-gateway
+no_verbose_logs: true
 
 # used in conjunction with sg_vars in vars/main.yml to provide single parameter override for the dictionaries
 sg_defaults:

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -5,6 +5,7 @@
     api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
 
 - name: Print some debug information
+  no_log: "{{ no_verbose_logs | bool }}"
   vars:
     msg: |
       SmartGateway Variables
@@ -83,6 +84,7 @@
 
 # used as part of the Deployment object in order to trigger pod restarts on ConfigMap change
 - name: Get Smart Gateway ConfigMap Environment
+  no_log: "{{ no_verbose_logs | bool }}"
   set_fact:
     smartgateway_resource_configmap:
       env: "{{ lookup('template', item.name) | from_yaml }}"
@@ -91,6 +93,7 @@
     - name: sg-core-configmap.yaml.j2
 
 - name: Deploy Smart Gateway
+  no_log: "{{ no_verbose_logs | bool }}"
   k8s:
     state: "{{ state }}"
     definition: "{{ lookup('template', item.name) | from_yaml }}"


### PR DESCRIPTION
Lower ANSIBLE_VERBOSITY from 4 to 2 and disable ANSIBLE_DEBUG_LOGS in shipped deployment manifests. Add no_verbose_logs role default (true) to guard tasks that template AMQP credentials and backend connection details, preventing their disclosure in operator pod logs during normal operation.

Related-to: OSPRH-32351


(cherry picked from commit 69a4da17ac0ef1db7ce470452e09f2cb0a21c3b2)