### PR TITLE
Add NetworkPolicy for smart-gateway workloads

### DIFF
--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -102,6 +102,13 @@
     - name: sg-core-configmap.yaml.j2
     - name: deployment.yaml.j2
 
+- name: Deploy Smart Gateway NetworkPolicy
+  k8s:
+    state: "{{ state }}"
+    definition: "{{ lookup('template', 'networkpolicy.yaml.j2') | from_yaml }}"
+  when:
+    - applications | selectattr('name','equalto','prometheus') | list | count > 0
+
 - name: Deploy services requested by this Smart Gateway
   include_tasks: base_service.yml
   loop: "{{ services }}"

--- a/roles/smartgateway/templates/networkpolicy.yaml.j2
+++ b/roles/smartgateway/templates/networkpolicy.yaml.j2
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: '{{ ansible_operator_meta.name }}-smartgateway'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+  labels:
+    app: smart-gateway
+    smart-gateway: '{{ ansible_operator_meta.name }}'
+spec:
+  podSelector:
+    matchLabels:
+      app: smart-gateway
+      smart-gateway: '{{ ansible_operator_meta.name }}'
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - port: 8083
+      protocol: TCP


### PR DESCRIPTION
Render a default-deny ingress NetworkPolicy for smart-gateway pods when the Prometheus application is enabled. Only port 8083 (oauth-proxy TLS) is permitted, matching the existing service exposure model.

Related-To: OSPRH-32356

Assisted-By: Claude Opus 4.6