### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you've found a security issue in this repository, please report it
+confidentially to Red Hat's Product Security team.
+
+Details and contact information: https://access.redhat.com/security/team/contact
+
+Do **not** open a public GitHub issue for security vulnerabilities.


### PR DESCRIPTION
Provides a coordinated disclosure channel pointing to Red Hat Product Security.

Based on: https://github.com/openstack-k8s-operators/.github/blob/main/SECURITY.md

Related-To: OSPRH-32358