### PR TITLE
Add ConfigMap-based resource limits to Smart Gateway containers

### DIFF
--- a/roles/smartgateway/defaults/main.yml
+++ b/roles/smartgateway/defaults/main.yml
@@ -12,6 +12,24 @@ block_event_bus: false
 service_account_name: smart-gateway
 no_verbose_logs: true
 
+# per-container resource limits, override via smart-gateway-resource-limits ConfigMap
+sg_resource_defaults:
+  oauth_proxy:
+    cpu_limit: "1"
+    memory_limit: "512Mi"
+    cpu_request: "50m"
+    memory_request: "64Mi"
+  bridge:
+    cpu_limit: "1"
+    memory_limit: "1Gi"
+    cpu_request: "100m"
+    memory_request: "128Mi"
+  sg_core:
+    cpu_limit: "2"
+    memory_limit: "8Gi"
+    cpu_request: "300m"
+    memory_request: "512Mi"
+
 # used in conjunction with sg_vars in vars/main.yml to provide single parameter override for the dictionaries
 sg_defaults:
   bridge:

--- a/roles/smartgateway/tasks/main.yml
+++ b/roles/smartgateway/tasks/main.yml
@@ -82,6 +82,64 @@
         name: smart-gateway
         namespace: "{{ ansible_operator_meta.namespace }}"
 
+- name: Check for existing resource limits ConfigMap
+  k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: 'smart-gateway-resource-limits'
+  register: resource_limits_cm
+
+- name: Create resource limits ConfigMap
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: 'smart-gateway-resource-limits'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+      data:
+        oauth_proxy_cpu_limit: "{{ sg_resource_defaults.oauth_proxy.cpu_limit }}"
+        oauth_proxy_memory_limit: "{{ sg_resource_defaults.oauth_proxy.memory_limit }}"
+        oauth_proxy_cpu_request: "{{ sg_resource_defaults.oauth_proxy.cpu_request }}"
+        oauth_proxy_memory_request: "{{ sg_resource_defaults.oauth_proxy.memory_request }}"
+        bridge_cpu_limit: "{{ sg_resource_defaults.bridge.cpu_limit }}"
+        bridge_memory_limit: "{{ sg_resource_defaults.bridge.memory_limit }}"
+        bridge_cpu_request: "{{ sg_resource_defaults.bridge.cpu_request }}"
+        bridge_memory_request: "{{ sg_resource_defaults.bridge.memory_request }}"
+        sg_core_cpu_limit: "{{ sg_resource_defaults.sg_core.cpu_limit }}"
+        sg_core_memory_limit: "{{ sg_resource_defaults.sg_core.memory_limit }}"
+        sg_core_cpu_request: "{{ sg_resource_defaults.sg_core.cpu_request }}"
+        sg_core_memory_request: "{{ sg_resource_defaults.sg_core.memory_request }}"
+  when: resource_limits_cm.resources | length == 0
+
+- name: Set resource limits from ConfigMap
+  vars:
+    cm_data: "{{ resource_limits_cm.resources[0].data }}"
+  set_fact:
+    sg_resources:
+      oauth_proxy:
+        cpu_limit: "{{ cm_data.oauth_proxy_cpu_limit | default(sg_resource_defaults.oauth_proxy.cpu_limit) }}"
+        memory_limit: "{{ cm_data.oauth_proxy_memory_limit | default(sg_resource_defaults.oauth_proxy.memory_limit) }}"
+        cpu_request: "{{ cm_data.oauth_proxy_cpu_request | default(sg_resource_defaults.oauth_proxy.cpu_request) }}"
+        memory_request: "{{ cm_data.oauth_proxy_memory_request | default(sg_resource_defaults.oauth_proxy.memory_request) }}"
+      bridge:
+        cpu_limit: "{{ cm_data.bridge_cpu_limit | default(sg_resource_defaults.bridge.cpu_limit) }}"
+        memory_limit: "{{ cm_data.bridge_memory_limit | default(sg_resource_defaults.bridge.memory_limit) }}"
+        cpu_request: "{{ cm_data.bridge_cpu_request | default(sg_resource_defaults.bridge.cpu_request) }}"
+        memory_request: "{{ cm_data.bridge_memory_request | default(sg_resource_defaults.bridge.memory_request) }}"
+      sg_core:
+        cpu_limit: "{{ cm_data.sg_core_cpu_limit | default(sg_resource_defaults.sg_core.cpu_limit) }}"
+        memory_limit: "{{ cm_data.sg_core_memory_limit | default(sg_resource_defaults.sg_core.memory_limit) }}"
+        cpu_request: "{{ cm_data.sg_core_cpu_request | default(sg_resource_defaults.sg_core.cpu_request) }}"
+        memory_request: "{{ cm_data.sg_core_memory_request | default(sg_resource_defaults.sg_core.memory_request) }}"
+  when: resource_limits_cm.resources | length > 0
+
+- name: Set resource limits from defaults
+  set_fact:
+    sg_resources: "{{ sg_resource_defaults }}"
+  when: resource_limits_cm.resources | length == 0
+
 # used as part of the Deployment object in order to trigger pod restarts on ConfigMap change
 - name: Get Smart Gateway ConfigMap Environment
   no_log: "{{ no_verbose_logs | bool }}"

--- a/roles/smartgateway/templates/deployment.yaml.j2
+++ b/roles/smartgateway/templates/deployment.yaml.j2
@@ -39,6 +39,13 @@ spec:
           capabilities:
             drop:
             - ALL
+        resources:
+          limits:
+            cpu: '{{ sg_resources.oauth_proxy.cpu_limit }}'
+            memory: {{ sg_resources.oauth_proxy.memory_limit }}
+          requests:
+            cpu: {{ sg_resources.oauth_proxy.cpu_request }}
+            memory: {{ sg_resources.oauth_proxy.memory_request }}
         args:
         - -https-address=:8083
         - -tls-cert=/etc/tls/private/tls.crt
@@ -80,6 +87,13 @@ spec:
           capabilities:
             drop:
             - ALL
+        resources:
+          limits:
+            cpu: '{{ sg_resources.bridge.cpu_limit }}'
+            memory: {{ sg_resources.bridge.memory_limit }}
+          requests:
+            cpu: {{ sg_resources.bridge.cpu_request }}
+            memory: {{ sg_resources.bridge.memory_request }}
         args:
 {%   if sg_vars.bridge.amqp_url is defined and sg_vars.bridge.amqp_url != "" %}
         - --amqp_url
@@ -137,6 +151,13 @@ spec:
           capabilities:
             drop:
             - ALL
+        resources:
+          limits:
+            cpu: '{{ sg_resources.sg_core.cpu_limit }}'
+            memory: {{ sg_resources.sg_core.memory_limit }}
+          requests:
+            cpu: {{ sg_resources.sg_core.cpu_request }}
+            memory: {{ sg_resources.sg_core.memory_request }}
         args:
           - -config
           - /etc/sg-core/sg-core.conf.yaml


### PR DESCRIPTION
Add ConfigMap-based resource limits to Smart Gateway containers

Operator creates a smart-gateway-resource-limits ConfigMap on first
run with per-container default upper bounds:
- oauth-proxy: cpu 1/50m, memory 512Mi/64Mi
- bridge: cpu 1/100m, memory 1Gi/128Mi
- sg-core: cpu 2/300m, memory 8Gi/512Mi

Users can edit the ConfigMap to adjust limits per container without
rebuilding the operator or modifying the CRD. On each reconciliation
the operator reads the ConfigMap and templates the values into the
corresponding containers.

Related-To: OSPRH-33057
